### PR TITLE
feat(evals): manage datasets from the UI - edit, delete, validate, in…

### DIFF
--- a/apps/api/forge/routers/evals.py
+++ b/apps/api/forge/routers/evals.py
@@ -40,6 +40,18 @@ async def create_dataset(project_id: str, body: DatasetIn, session: AsyncSession
     return _out(ds)
 
 
+@router.patch("/{dataset_id}")
+async def update_dataset(project_id: str, dataset_id: str, body: DatasetIn, session: AsyncSession = Depends(get_session),
+                         tenant_id: str = Depends(current_tenant_id),
+                         _: CurrentUser = Depends(require_role("editor"))):
+    ds = await EvalService.get(session, tenant_id, dataset_id)
+    if not ds:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "dataset not found")
+    ds = await EvalService.update(session, ds, name=body.name, workflow_id=body.workflow_id,
+                                  score_mode=body.score_mode, items=body.items)
+    return _out(ds)
+
+
 @router.delete("/{dataset_id}")
 async def delete_dataset(project_id: str, dataset_id: str, session: AsyncSession = Depends(get_session),
                          tenant_id: str = Depends(current_tenant_id),

--- a/apps/api/forge/services/evals.py
+++ b/apps/api/forge/services/evals.py
@@ -71,6 +71,16 @@ class EvalService:
         return ds
 
     @staticmethod
+    async def update(session, ds: Dataset, *, name, workflow_id=None, score_mode="contains", items=None) -> Dataset:
+        ds.name = name
+        ds.workflow_id = workflow_id
+        ds.score_mode = score_mode
+        ds.items = items or []
+        await session.commit()
+        await session.refresh(ds)
+        return ds
+
+    @staticmethod
     async def delete(session, ds: Dataset) -> None:
         await session.delete(ds)
         await session.commit()

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -133,7 +133,9 @@ body {
 .input:focus, .textarea:focus, .select:focus { border-color:var(--signal); box-shadow:0 0 0 3px var(--signal-glow); }
 .input.mono { font-family:var(--font-mono); font-size:12.5px; }
 .textarea { height:auto; padding:var(--s2) var(--s3); line-height:19px; resize:vertical; min-height:64px; }
-.select { appearance:none; padding-right:var(--s6); cursor:pointer; }
+.select { appearance:none; padding-right:var(--s8); cursor:pointer;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%237A848F' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat:no-repeat; background-position:right var(--s3) center; }
 .field-label { display:block; font-size:12px; font-weight:600; color:var(--fg-1); margin-bottom:6px; }
 .field-help { font-size:11.5px; color:var(--fg-2); margin-top:5px; line-height:15px; }
 
@@ -178,7 +180,7 @@ body {
 .tbl { width:100%; border-collapse:collapse; }
 .tbl th { font-size:11px; text-transform:uppercase; letter-spacing:.05em; color:var(--fg-2); font-weight:600; text-align:left; padding:0 var(--s3); height:34px; border-bottom:1px solid var(--line); white-space:nowrap; }
 .tbl td { padding:0 var(--s3); height:44px; border-bottom:1px solid var(--line); font-size:13px; vertical-align:middle; }
-.tbl tr.row { transition:background var(--dur-fast); cursor:pointer; }
+.tbl tr.row { display:table-row; transition:background var(--dur-fast); cursor:pointer; }
 .tbl tr.row:hover { background:var(--bg-3); }
 .tbl-dense td { height:36px; }
 

--- a/apps/web/components/primitives.tsx
+++ b/apps/web/components/primitives.tsx
@@ -1,6 +1,7 @@
 "use client";
 /* Forge shared UI primitives - ported from the design handoff (primitives.jsx). */
 import { CSSProperties, ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Icon } from "./icons";
 
 /* ---------------- Sparkline ---------------- */
@@ -157,14 +158,20 @@ export function Segmented({ options, value, onChange }: { options: (string | { v
 
 /* ---------------- Modal ---------------- */
 export function Modal({ open, onClose, children, width = 520, title, footer }: { open: boolean; onClose: () => void; children: ReactNode; width?: number; title?: string; footer?: ReactNode }) {
+  // Portal to <body> so the fixed overlay escapes any transformed ancestor (e.g. the
+  // `.fade-up` screen wrapper). A transformed ancestor becomes the containing block for
+  // `position:fixed`, which otherwise traps the modal inside the content column and clips
+  // its header. `mounted` avoids touching `document` during SSR / first hydration.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
   useEffect(() => {
     if (!open) return;
     const h = (e: KeyboardEvent) => e.key === "Escape" && onClose();
     window.addEventListener("keydown", h);
     return () => window.removeEventListener("keydown", h);
   }, [open, onClose]);
-  if (!open) return null;
-  return (
+  if (!open || !mounted) return null;
+  return createPortal(
     <div className="fade-in" style={{ position: "fixed", inset: 0, zIndex: 8000, background: "rgba(8,10,14,.5)", backdropFilter: "blur(3px)", display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }} onMouseDown={onClose}>
       <div className="card fade-up" style={{ width, maxWidth: "94vw", maxHeight: "88vh", boxShadow: "var(--sh-pop)", display: "flex", flexDirection: "column" }} onMouseDown={(e) => e.stopPropagation()}>
         {title && (
@@ -176,7 +183,8 @@ export function Modal({ open, onClose, children, width = 520, title, footer }: {
         <div className="scroll-y" style={{ padding: 18, flex: 1 }}>{children}</div>
         {footer && <div className="row gap2" style={{ padding: "12px 18px", borderTop: "1px solid var(--line)", justifyContent: "flex-end" }}>{footer}</div>}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/apps/web/components/screens/platform.tsx
+++ b/apps/web/components/screens/platform.tsx
@@ -6,6 +6,40 @@ import { Icon } from "../icons";
 import { Field, Modal } from "../primitives";
 import { api, Channel, Dataset, EvalReport, Handoff, Trigger, Workflow } from "@/lib/api";
 
+/* Validate the Cases JSON before it is POSTed: it must be a non-empty array of objects
+   that each carry a string `input`. Returns the parsed cases (or null) + a human error so
+   the modal can block Create instead of silently saving an empty / un-runnable dataset. */
+function parseCases(text: string): { cases: any[] | null; error: string | null } {
+  let v: unknown;
+  try { v = JSON.parse(text); } catch { return { cases: null, error: "Not valid JSON." }; }
+  if (!Array.isArray(v)) return { cases: null, error: "Expected a JSON array of cases." };
+  if (v.length === 0) return { cases: null, error: "Add at least one case." };
+  for (const c of v) {
+    if (typeof c !== "object" || c === null || typeof (c as any).input !== "string")
+      return { cases: null, error: 'Each case needs a string "input" field.' };
+  }
+  return { cases: v as any[], error: null };
+}
+
+const EMPTY_DATASET_FORM = { name: "", workflow_id: "", score_mode: "contains", items: '[\n  {"input": "what are your hours?", "expected": "9am"}\n]' };
+
+/* One labelled block in an expanded eval result (input / expected / answer / reason). */
+function ResultField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="col" style={{ gap: 3 }}>
+      <div className="t-micro">{label}</div>
+      <div className="t-caption" style={{ whiteSpace: "pre-wrap", wordBreak: "break-word", color: "var(--fg-1)", maxHeight: 220, overflowY: "auto" }}>{value}</div>
+    </div>
+  );
+}
+
+const SCORING_HELP: Record<string, string> = {
+  contains: "Pass if the answer contains the expected text (case-insensitive).",
+  exact: "Pass if the answer exactly equals the expected text.",
+  regex: "Pass if the expected pattern (regex) matches the answer.",
+  judge: "An LLM grades whether the answer satisfies the expected behavior.",
+};
+
 function Header({ title, subtitle, action }: { title: string; subtitle?: string; action?: React.ReactNode }) {
   return (
     <div className="row spread" style={{ marginBottom: 18 }}>
@@ -135,55 +169,116 @@ export function DatasetsScreen({ project }: { project: any }) {
   const [datasets, setDatasets] = useState<Dataset[]>([]);
   const wfs = useWorkflows(project?.id);
   const [open, setOpen] = useState(false);
-  const [form, setForm] = useState({ name: "", workflow_id: "", score_mode: "contains", items: '[\n  {"input": "what are your hours?", "expected": "9am"}\n]' });
+  const [editing, setEditing] = useState<Dataset | null>(null);
+  const [form, setForm] = useState(EMPTY_DATASET_FORM);
   const [report, setReport] = useState<EvalReport | null>(null);
+  const [ranDataset, setRanDataset] = useState<Dataset | null>(null);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [runError, setRunError] = useState<string | null>(null);
   const [running, setRunning] = useState<string | null>(null);
   const reload = useCallback(() => { if (project?.id) api.listDatasets(project.id).then(setDatasets).catch(() => setDatasets([])); }, [project?.id]);
   useEffect(() => { reload(); }, [reload]);
 
-  async function create() {
-    let items: any[] = [];
-    try { items = JSON.parse(form.items); } catch { /* ignore */ }
-    await api.createDataset(project.id, { name: form.name, workflow_id: form.workflow_id || undefined, score_mode: form.score_mode, items });
+  // Guard the form so we never save a dataset that can't be run: a name, a bound
+  // workflow, and a valid non-empty case list are all required.
+  const { cases, error: casesError } = parseCases(form.items);
+  const canSave = form.name.trim() !== "" && form.workflow_id !== "" && !!cases;
+
+  function openCreate() { setEditing(null); setForm(EMPTY_DATASET_FORM); setOpen(true); }
+  function openEdit(d: Dataset) {
+    setEditing(d);
+    setForm({ name: d.name, workflow_id: d.workflow_id || "", score_mode: d.score_mode, items: JSON.stringify(d.items ?? [], null, 2) });
+    setOpen(true);
+  }
+  async function save() {
+    if (!canSave || !cases) return;
+    const body = { name: form.name.trim(), workflow_id: form.workflow_id, score_mode: form.score_mode, items: cases };
+    if (editing) await api.updateDataset(project.id, editing.id, body);
+    else await api.createDataset(project.id, body);
     setOpen(false); reload();
   }
-  async function run(d: Dataset) { setRunning(d.id); setReport(null); try { setReport(await api.runDataset(project.id, d.id)); } finally { setRunning(null); reload(); } }
+  async function remove(d: Dataset) {
+    if (!window.confirm(`Delete dataset "${d.name}"?\n\nThis removes its cases and last run result. This cannot be undone.`)) return;
+    await api.deleteDataset(project.id, d.id);
+    if (editing?.id === d.id) setOpen(false);
+    reload();
+  }
+  async function run(d: Dataset) {
+    setRunning(d.id); setReport(null); setRunError(null); setRanDataset(d); setExpanded(new Set());
+    try {
+      const res = await api.runDataset(project.id, d.id);
+      if ("error" in res) setRunError(res.error);
+      else setReport(res);
+    } catch (e: any) {
+      setRunError(e?.message || "The run request failed.");
+    } finally {
+      setRunning(null); reload();
+    }
+  }
 
   return (
     <Shell>
       <Header title="Evaluations" subtitle="Run input → expected-output datasets against a workflow to score quality and catch regressions."
-        action={<button className="btn btn-primary btn-sm" onClick={() => setOpen(true)}><Icon name="plus" size={14} />New dataset</button>} />
+        action={<button className="btn btn-primary btn-sm" onClick={openCreate}><Icon name="plus" size={14} />New dataset</button>} />
       <div className="col gap2">
         {datasets.map((d) => (
           <div key={d.id} className="card" style={{ padding: 14 }}>
             <div className="row spread">
-              <div className="row gap2"><Icon name="validate" size={15} /><span className="t-h3">{d.name}</span><span className="typechip">{d.score_mode}</span><span className="fg-2 t-caption">{d.n_items} cases</span></div>
+              <div className="row gap2"><Icon name="validate" size={15} /><span className="t-h3">{d.name}</span><span className="typechip">{d.score_mode}</span><span className="fg-2 t-caption">{d.n_items} cases</span>{!d.workflow_id && <span className="pill pill-warn">no workflow</span>}</div>
               <div className="row gap2">
-                {d.last_pass_rate != null && <span className="pill" style={{ background: d.last_pass_rate >= 0.8 ? "var(--ok-bg, #e6f6ec)" : "var(--bg-3)" }}>{Math.round(d.last_pass_rate * 100)}% pass</span>}
-                <button className="btn btn-secondary btn-sm" disabled={running === d.id} onClick={() => run(d)}><Icon name="play" size={13} />{running === d.id ? "Running…" : "Run"}</button>
+                {d.last_pass_rate != null && <span className={`pill ${d.last_pass_rate >= 0.8 ? "pill-ok" : "pill-muted"}`}>{Math.round(d.last_pass_rate * 100)}% pass</span>}
+                <button className="btn btn-secondary btn-sm" disabled={running === d.id || !d.workflow_id} title={!d.workflow_id ? "Bind a workflow to this dataset before running it" : undefined} onClick={() => run(d)}><Icon name="play" size={13} />{running === d.id ? "Running…" : "Run"}</button>
+                <button className="iconbtn" title="Edit dataset" onClick={() => openEdit(d)}><Icon name="edit" size={15} /></button>
+                <button className="iconbtn" title="Delete dataset" onClick={() => remove(d)}><Icon name="trash" size={15} /></button>
               </div>
             </div>
           </div>
         ))}
         {datasets.length === 0 && <div className="fg-2 t-caption">No datasets yet.</div>}
       </div>
-      {report && (
-        <div className="card" style={{ padding: 16, marginTop: 16 }}>
-          <div className="t-h3" style={{ marginBottom: 8 }}>Last run · {report.summary.passed}/{report.summary.total} passed ({Math.round(report.summary.pass_rate * 100)}%)</div>
-          {report.results.map((r, i) => (
-            <div key={i} className="row spread" style={{ padding: "6px 0", borderTop: "1px solid var(--line)" }}>
-              <span className="t-caption truncate" style={{ flex: 1 }}>{r.input}</span>
-              <span className="pill" style={{ background: r.passed ? "var(--ok-bg, #e6f6ec)" : "var(--danger-bg, #fde8e8)" }}>{r.passed ? "pass" : "fail"}</span>
-            </div>
-          ))}
+      {runError && (
+        <div className="card" style={{ padding: 14, marginTop: 16, borderColor: "var(--err)", background: "var(--err-bg)" }}>
+          <div className="t-h3" style={{ color: "var(--err)", marginBottom: 2 }}>Run failed</div>
+          <div className="t-caption" style={{ color: "var(--fg-1)" }}>{runError}</div>
         </div>
       )}
-      <Modal open={open} onClose={() => setOpen(false)} title="New dataset" width={520}
-        footer={<><button className="btn btn-ghost" onClick={() => setOpen(false)}>Cancel</button><button className="btn btn-primary" onClick={create}>Create</button></>}>
-        <Field label="Name"><input className="input" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="Smoke tests" /></Field>
-        <Field label="Workflow"><select className="select" value={form.workflow_id} onChange={(e) => setForm((f) => ({ ...f, workflow_id: e.target.value }))}><option value="">Select…</option>{wfs.map((w) => <option key={w.id} value={w.id}>{w.name}</option>)}</select></Field>
-        <Field label="Scoring"><select className="select" value={form.score_mode} onChange={(e) => setForm((f) => ({ ...f, score_mode: e.target.value }))}><option value="contains">contains</option><option value="exact">exact</option><option value="regex">regex</option><option value="judge">LLM judge</option></select></Field>
-        <Field label="Cases (JSON)" help='[{"input": "...", "expected": "..."}]'><textarea className="textarea mono" rows={6} style={{ fontSize: 12 }} value={form.items} onChange={(e) => setForm((f) => ({ ...f, items: e.target.value }))} /></Field>
+      {report?.summary && (
+        <div className="card" style={{ padding: 16, marginTop: 16 }}>
+          <div className="t-h3" style={{ marginBottom: 4 }}>Last run{ranDataset ? ` · ${ranDataset.name}` : ""} · {report.summary.passed}/{report.summary.total} passed ({Math.round(report.summary.pass_rate * 100)}%)</div>
+          <div className="fg-2 t-caption" style={{ marginBottom: 4 }}>Select a case to see its output{ranDataset?.score_mode === "judge" ? " and the judge's reason" : ""}.</div>
+          {report.results.map((r, i) => {
+            const isOpen = expanded.has(i);
+            return (
+              <div key={i} style={{ borderTop: "1px solid var(--line)" }}>
+                <button className="row spread" style={{ width: "100%", padding: "8px 0", background: "none", border: "none", cursor: "pointer", textAlign: "left", color: "inherit" }}
+                  onClick={() => setExpanded((prev) => { const n = new Set(prev); if (n.has(i)) n.delete(i); else n.add(i); return n; })}>
+                  <span className="row gap2" style={{ flex: 1, minWidth: 0 }}>
+                    <Icon name={isOpen ? "chevdown" : "chevright"} size={14} />
+                    <span className="t-caption truncate">{r.input || "(empty input)"}</span>
+                  </span>
+                  <span className={`pill ${r.passed ? "pill-ok" : "pill-err"}`}>{r.passed ? "pass" : "fail"}</span>
+                </button>
+                {isOpen && (
+                  <div className="col" style={{ gap: 10, padding: "2px 0 12px 22px" }}>
+                    {r.expected && <ResultField label="Expected" value={r.expected} />}
+                    <ResultField label="Output" value={r.answer || "(no output)"} />
+                    {r.reason && <ResultField label={ranDataset?.score_mode === "judge" ? "Judge reason" : "Reason"} value={r.reason} />}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <Modal open={open} onClose={() => setOpen(false)} title={editing ? "Edit dataset" : "New dataset"} width={520}
+        footer={<><button className="btn btn-ghost" onClick={() => setOpen(false)}>Cancel</button><button className="btn btn-primary" onClick={save} disabled={!canSave}>{editing ? "Save" : "Create"}</button></>}>
+        <Field label="Name" required><input className="input" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="Smoke tests" /></Field>
+        <Field label="Workflow" required help={wfs.length === 0 ? "No workflows yet — create and publish one first." : "The workflow each case is run against."}><select className="select" value={form.workflow_id} onChange={(e) => setForm((f) => ({ ...f, workflow_id: e.target.value }))}><option value="">Select…</option>{wfs.map((w) => <option key={w.id} value={w.id}>{w.name}</option>)}</select></Field>
+        <Field label="Scoring" help={SCORING_HELP[form.score_mode]}><select className="select" value={form.score_mode} onChange={(e) => setForm((f) => ({ ...f, score_mode: e.target.value }))}><option value="contains">contains</option><option value="exact">exact</option><option value="regex">regex</option><option value="judge">LLM judge</option></select></Field>
+        <Field label="Cases (JSON)" help='Array of {"input": "...", "expected": "..."}'>
+          <textarea className="textarea mono" rows={6} style={{ fontSize: 12 }} value={form.items} onChange={(e) => setForm((f) => ({ ...f, items: e.target.value }))} />
+          {casesError && <div className="t-caption" style={{ color: "var(--err)", marginTop: 6 }}>{casesError}</div>}
+        </Field>
       </Modal>
     </Shell>
   );

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -439,8 +439,10 @@ export const api = {
   listDatasets: (pid: string) => json<Dataset[]>(`/v1/projects/${pid}/datasets`),
   createDataset: (pid: string, body: { name: string; workflow_id?: string; score_mode?: string; items?: any[] }) =>
     json<Dataset>(`/v1/projects/${pid}/datasets`, { method: "POST", body: JSON.stringify(body) }),
+  updateDataset: (pid: string, did: string, body: { name: string; workflow_id?: string; score_mode?: string; items?: any[] }) =>
+    json<Dataset>(`/v1/projects/${pid}/datasets/${did}`, { method: "PATCH", body: JSON.stringify(body) }),
   runDataset: (pid: string, did: string) =>
-    json<EvalReport>(`/v1/projects/${pid}/datasets/${did}/run`, { method: "POST" }),
+    json<EvalRunResult>(`/v1/projects/${pid}/datasets/${did}/run`, { method: "POST" }),
   deleteDataset: (pid: string, did: string) =>
     json<{ ok: boolean }>(`/v1/projects/${pid}/datasets/${did}`, { method: "DELETE" }),
   // handoff inbox
@@ -458,6 +460,10 @@ export interface Channel { id: string; type: string; name: string; workflow_id?:
 export interface Trigger { id: string; workflow_id: string; node_id: string; kind: string; enabled: boolean; config: Record<string, any>; webhook_url?: string; last_fired_at?: string | null; }
 export interface Dataset { id: string; name: string; workflow_id?: string | null; score_mode: string; items: any[]; n_items: number; last_pass_rate?: number | null; }
 export interface EvalReport { summary: { total: number; passed: number; pass_rate: number }; results: { input: string; expected: string; answer: string; passed: boolean; reason?: string | null }[]; }
+/** A dataset run either scores (EvalReport) or fails before scoring (no workflow bound,
+ *  quota exceeded, …) - the backend returns a bare `{error}` for the latter, so callers
+ *  must narrow before reading `summary`/`results`. */
+export type EvalRunResult = EvalReport | { error: string };
 export interface Handoff { id: string; run_id: string; workflow_id?: string | null; customer?: string | null; customer_message?: string | null; reason?: string | null; status: string; at?: string | null; }
 export interface EmbedSettings { enabled: boolean; allowed_origins: string[]; workflow_id?: string | null; publishable_key?: string | null; embed_src?: string | null; }
 


### PR DESCRIPTION
…spect results

- api: add PATCH /datasets/{id} + EvalService.update to edit saved datasets
- web: DatasetsScreen gains edit/delete, JSON case validation with inline errors, required-field guards, per-case expandable run output, and run- failure surfacing (narrows the new EvalRunResult = EvalReport | {error} union)
- fix(web): portal Modal to <body> so the fixed overlay escapes transformed ancestors that were clipping the modal header inside the content column
- style(web): custom select chevron + table row display fix

<!-- Thanks for contributing to Forge! Please fill this out to speed up review. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link the issue: Closes #123 -->

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Performance
- [ ] Refactor (no behavior change)
- [ ] Docs / chore

## Checklist

- [x] Backend: `ruff check forge migrations` is clean and `pytest -q` passes (from `apps/api`)
- [x] New/changed backend code is `mypy`-clean
- [x] Frontend: `pnpm --filter web build` passes (from repo root)
- [ ] Shared schemas (`packages/schemas`) updated if node/tool config changed
- [ ] Tests added/updated for the change (characterization test for behavior-preserving refactors)
- [x] `CHANGELOG.md` updated under **Unreleased** (for user-facing changes)
- [ ] No secrets, tokens, or customer data in the diff

## Notes for reviewers

<!-- Anything that needs special attention, screenshots for UI changes, migration notes, etc. -->
