### PR TITLE
fix(security): resolve CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: CI only reads the checked-out code; it never writes back to the repo.
+permissions:
+  contents: read
+
 jobs:
   api:
     name: API - lint + tests

--- a/apps/api/forge/knowledge/embeddings.py
+++ b/apps/api/forge/knowledge/embeddings.py
@@ -169,7 +169,9 @@ _FALLBACK_WARNED: set[str] = set()
 def _key_fp(api_key: str | None) -> str:
     if not api_key:
         return "env"
-    return hashlib.sha256(api_key.encode()).hexdigest()[:16]
+    # Not a security hash: this only namespaces the in-process embedder cache by key, so the
+    # plaintext key never becomes a dict key. usedforsecurity=False documents that intent.
+    return hashlib.sha256(api_key.encode(), usedforsecurity=False).hexdigest()[:16]
 
 
 def _warn_once(model: str, msg: str) -> None:

--- a/apps/api/forge/routers/mcp_server.py
+++ b/apps/api/forge/routers/mcp_server.py
@@ -163,7 +163,9 @@ async def mcp_rpc(project_id: str, request: Request):
         try:
             result = await tool.ainvoke(args)
             return _rpc(rid, {"content": [{"type": "text", "text": str(result)}], "isError": False})
-        except Exception as e:  # noqa: BLE001
-            return _rpc(rid, {"content": [{"type": "text", "text": f"error: {e}"}], "isError": True})
+        except Exception:  # noqa: BLE001
+            # Don't leak internal error/stack detail to the external MCP client; log it server-side.
+            log.exception("mcp tool invocation failed (project=%s, tool=%s)", project_id, name)
+            return _rpc(rid, {"content": [{"type": "text", "text": "error: tool invocation failed"}], "isError": True})
 
     return _rpc(rid, error={"code": -32601, "message": f"method not found: {method}"})

--- a/apps/api/forge/routers/oauth.py
+++ b/apps/api/forge/routers/oauth.py
@@ -116,8 +116,10 @@ async def oauth_callback(
         return HTMLResponse("<h3>Missing code/state</h3>", status_code=400)
     try:
         claims = decode_token(state, expected_type="oauth_state")
-    except TokenError as e:
-        return HTMLResponse(f"<h3>Invalid or expired state</h3><p>{escape(str(e))}</p>", status_code=400)
+    except TokenError:
+        # Don't reflect the decode error detail on this public callback page; the generic
+        # message is enough for the user and the specifics aren't security-relevant to them.
+        return HTMLResponse("<h3>Invalid or expired state</h3>", status_code=400)
     tenant_id, project_id, ap_id = claims["tid"], claims["pid"], claims["ap"]
     ap = await _load(session, tenant_id, project_id, ap_id)
     cfg = ap.config or {}

--- a/apps/web/components/screens/deploy.tsx
+++ b/apps/web/components/screens/deploy.tsx
@@ -148,7 +148,13 @@ export function ConnectScreen({ project }: { project: any }) {
     await api.updateProject(project.id, { config: { ...(p.config || {}), mcp_api_key: next || undefined } });
     setSave("saved"); setTimeout(() => setSave("idle"), 1200);
   }
-  const genKey = () => saveKey("fmcp_" + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2));
+  const genKey = () => {
+    // A shared MCP API key is a credential, so use the CSPRNG (crypto.getRandomValues),
+    // never Math.random() - the latter is predictable and unsafe for secret material.
+    const bytes = new Uint8Array(24);
+    crypto.getRandomValues(bytes);
+    saveKey("fmcp_" + Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(""));
+  };
 
   const activeMeta = CONN_SECTIONS.find((s) => s.id === section)!;
   return (


### PR DESCRIPTION
Addresses the true-positive CodeQL findings on main:

- deploy.tsx: mint the shared MCP API key with crypto.getRandomValues instead of Math.random() (insecure randomness for a credential) [#4/#5].
- ci.yml: add a top-level least-privilege `permissions: contents: read` block so CI has no implicit write scope [#1/#12].
- mcp_server.py: the tool-invocation path no longer echoes internal exception detail to the external MCP client; log server-side and return a generic error (matches the earlier run-path fix) [#9].
- embeddings.py: mark the api-key cache fingerprint hash usedforsecurity=False - it namespaces an in-process cache, not security storage [#11].
- oauth.py: stop reflecting the token-decode error detail on the public OAuth callback page; keep the generic message [#10].

Not changed (documented as dismissals):
- ssrf.py:205 (#6, Critical) is a FALSE POSITIVE: this IS the centralized egress guard - validate_url() runs before the request and on every redirect hop; CodeQL doesn't model it as a sanitizer.
- test_rag_floor_fixes.py:187 (#18) is a FALSE POSITIVE: `crawled` is a set, so `in` is exact membership, not a substring check.
- mcp_clients.py:102/104 (#7/#8) intentionally surface connect/auth errors to the authenticated admin testing their own MCP server (debuggability).

<!-- Thanks for contributing to Forge! Please fill this out to speed up review. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link the issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance
- [ ] Refactor (no behavior change)
- [ ] Docs / chore

## Checklist

- [ ] Backend: `ruff check forge migrations` is clean and `pytest -q` passes (from `apps/api`)
- [ ] New/changed backend code is `mypy`-clean
- [ ] Frontend: `pnpm --filter web build` passes (from repo root)
- [ ] Shared schemas (`packages/schemas`) updated if node/tool config changed
- [ ] Tests added/updated for the change (characterization test for behavior-preserving refactors)
- [ ] `CHANGELOG.md` updated under **Unreleased** (for user-facing changes)
- [ ] No secrets, tokens, or customer data in the diff

## Notes for reviewers

<!-- Anything that needs special attention, screenshots for UI changes, migration notes, etc. -->
