### PR TITLE
refactor(web): widen screen layouts + tool card and sidebar polish

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -81,8 +81,8 @@ function App() {
   const project = view.project ? cards.find((c) => c.id === view.project) || projects.find((p) => p.id === view.project) : null;
   const go = (v: View) => setView(v);
   const navScreen = (screen: string) => setView((v) => ({ ...v, name: "project", screen }));
-  async function deleteProject(projectToDelete: { id: string; name: string }) {
-    if (!window.confirm(`Delete project "${projectToDelete.name}"?\n\nThis removes its workflows, agents, tools, auth providers, knowledge, secrets, runs, and traces. This cannot be undone.`)) return;
+  async function deleteProject(projectToDelete: { id: string; name: string }, opts?: { skipConfirm?: boolean }) {
+    if (!opts?.skipConfirm && !window.confirm(`Delete project "${projectToDelete.name}"?\n\nThis removes its workflows, agents, tools, auth providers, knowledge, secrets, runs, and traces. This cannot be undone.`)) return;
     await api.deleteProject(projectToDelete.id);
     setProjects((prev) => prev.filter((p) => p.id !== projectToDelete.id));
     setRefreshNonce((n) => n + 1); // refetches dashboard stats (drops the deleted project's counts)
@@ -144,7 +144,7 @@ function App() {
       </div>
     ) : (
       <div className="row gap2">
-        <button className="btn btn-secondary btn-sm" onClick={() => setAssistantOpen(true)}><Icon name="sparkles" size={14} />Forge Assistant</button>
+        <button className="btn btn-secondary" onClick={() => setAssistantOpen(true)} style={{ height: 32 }}><Icon name="sparkles" size={14} />Forge Assistant</button>
       </div>
     );
 
@@ -185,7 +185,7 @@ function App() {
       );
     if (view.name === "project") {
       switch (view.screen) {
-        case "overview": return <OverviewScreen project={project} onNav={navScreen} onDeleteProject={deleteProject} />;
+        case "overview": return <OverviewScreen project={project} onNav={navScreen} />;
         case "playground": return <PlaygroundScreen project={project} />;
         case "workflows": return <WorkflowsScreen project={project} onOpen={(w) => { setSelWorkflow(w); navScreen("workflow-canvas"); }} />;
         case "workflow-canvas": return <WorkflowCanvas project={project} workflowId={selWorkflow?.id} onWorkflowChange={setSelWorkflow} onBack={() => navScreen("workflows")} onRun={() => navScreen("playground")} onRegisterFlush={(fn) => { canvasFlushRef.current = fn; }} />;
@@ -205,7 +205,7 @@ function App() {
         case "traces": return <TracesScreen project={project} />;
         case "connect": return <ConnectScreen project={project} />;
         case "embed": return <EmbedScreen project={project} />;
-        case "settings": return <SettingsScreen project={project} />;
+        case "settings": return <SettingsScreen project={project} onDeleteProject={(p) => deleteProject(p, { skipConfirm: true })} />;
         default: return <OverviewScreen project={project} onNav={navScreen} />;
       }
     }

--- a/apps/web/components/primitives.tsx
+++ b/apps/web/components/primitives.tsx
@@ -235,7 +235,7 @@ export function Field({ label, help, children, required }: { label?: string; hel
 }
 
 /* ---------------- Tabs ---------------- */
-export function Tabs({ tabs, value, onChange }: { tabs: (string | { value: string; label: string; count?: number })[]; value: string; onChange: (v: string) => void }) {
+export function Tabs({ tabs, value, onChange, equal }: { tabs: (string | { value: string; label: string; count?: number })[]; value: string; onChange: (v: string) => void; equal?: boolean }) {
   return (
     <div className="row" style={{ gap: 2, borderBottom: "1px solid var(--line)" }}>
       {tabs.map((t) => {
@@ -244,7 +244,7 @@ export function Tabs({ tabs, value, onChange }: { tabs: (string | { value: strin
         const active = value === val;
         return (
           <button key={val} onClick={() => onChange(val)}
-            style={{ background: "none", border: "none", cursor: "pointer", padding: "9px 12px", fontSize: 13, fontWeight: 600, fontFamily: "var(--font-ui)", color: active ? "var(--fg-0)" : "var(--fg-2)", borderBottom: "2px solid " + (active ? "var(--accent)" : "transparent"), marginBottom: -1, transition: "color var(--dur-fast)" }}>
+            style={{ flex: equal ? "1 1 0" : "0 0 auto", minWidth: 0, textAlign: "center", background: "none", border: "none", cursor: "pointer", padding: "9px 12px", fontSize: 13, fontWeight: 600, fontFamily: "var(--font-ui)", color: active ? "var(--fg-0)" : "var(--fg-2)", borderBottom: "2px solid " + (active ? "var(--accent)" : "transparent"), marginBottom: -1, transition: "color var(--dur-fast)" }}>
             {lab}
             {typeof t === "object" && t.count != null && <span className="badge" style={{ marginLeft: 6 }}>{t.count}</span>}
           </button>

--- a/apps/web/components/screens/agents.tsx
+++ b/apps/web/components/screens/agents.tsx
@@ -46,7 +46,7 @@ export function AgentsScreen({ project, onOpen }: { project: any; onOpen: (a: Ag
 
   return (
     <div className="scroll-y" style={{ flex: 1, padding: "24px 28px" }}>
-      <div className="fade-up" style={{ maxWidth: 1000, margin: "0 auto" }}>
+      <div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>
         <div className="row spread" style={{ marginBottom: 18 }}>
           <div>
             <div className="t-display">Agents</div>
@@ -140,7 +140,7 @@ export function AgentConfigScreen({ project, agentId, onBack }: { project: any; 
       </div>
       <div className="row" style={{ flex: 1, minHeight: 0, alignItems: "stretch" }}>
         <div className="scroll-y grow" style={{ padding: 24 }}>
-          <div style={{ maxWidth: 640, margin: "0 auto" }}>
+          <div style={{ maxWidth: 960, margin: "0 auto" }}>
             <AgentConfig config={config} onChange={setConfig} tools={tools} mcpServers={mcpServers} components={components} folders={folders} kinds={kinds} />
           </div>
         </div>

--- a/apps/web/components/screens/auth.tsx
+++ b/apps/web/components/screens/auth.tsx
@@ -186,7 +186,7 @@ function ProviderDetail({ project, provider, onSaved }: { project: any; provider
   }
 
   return (
-    <div style={{ maxWidth: 640 }}>
+    <div style={{ maxWidth: 960 }}>
       <div className="row spread" style={{ marginBottom: 18 }}>
         <div className="row gap3">
           <Tile icon="auth" color="var(--accent)" size={40} glow />

--- a/apps/web/components/screens/deploy.tsx
+++ b/apps/web/components/screens/deploy.tsx
@@ -177,7 +177,7 @@ export function ConnectScreen({ project }: { project: any }) {
 
         {/* content */}
         <div className="scroll-y grow" style={{ minWidth: 0 }}>
-          <div className="fade-up" style={{ maxWidth: 820, margin: "0 auto", padding: "24px 28px" }}>
+          <div className="fade-up" style={{ maxWidth: 960, margin: "0 auto", padding: "24px 28px" }}>
             <div style={{ marginBottom: 18 }}>
               <div className="t-display">{activeMeta.label}</div>
               <div className="fg-1" style={{ marginTop: 3 }}>{activeMeta.sub}</div>

--- a/apps/web/components/screens/embed.tsx
+++ b/apps/web/components/screens/embed.tsx
@@ -113,7 +113,7 @@ export function EmbedPanel({ project }: { project: any }) {
 export function EmbedScreen({ project }: { project: any }) {
   return (
     <div className="scroll-y" style={{ flex: 1, padding: "24px 28px" }}>
-      <div style={{ maxWidth: 760, margin: "0 auto" }} className="col gap4">
+      <div style={{ maxWidth: 960, margin: "0 auto" }} className="col gap4">
         <div className="row gap2">
           <Tile icon="grid" color="var(--io-json)" size={30} />
           <div>

--- a/apps/web/components/screens/home.tsx
+++ b/apps/web/components/screens/home.tsx
@@ -73,7 +73,7 @@ export function DashboardScreen({
   ];
   return (
     <div className="scroll-y" style={{ flex: 1, padding: "28px 32px" }}>
-      <div className="fade-up" style={{ maxWidth: 1180, margin: "0 auto" }}>
+      <div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>
         <div className="row spread" style={{ marginBottom: 22, alignItems: "flex-end" }}>
           <div>
             <div className="t-display-lg">Welcome to Forge</div>
@@ -212,12 +212,11 @@ export function DashboardScreen({
 }
 
 /* ============ PROJECT OVERVIEW ============ */
-export function OverviewScreen({ project, onNav, onDeleteProject }: { project: any; onNav: (s: string) => void; onDeleteProject?: (project: { id: string; name: string }) => Promise<void> | void }) {
+export function OverviewScreen({ project, onNav }: { project: any; onNav: (s: string) => void }) {
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [counts, setCounts] = useState<ProjectCounts | null>(null);
   const [stats, setStats] = useState<ProjectStats | null>(null);
   const [tab, setTab] = useState("overview");
-  const [deleting, setDeleting] = useState(false);
   useEffect(() => {
     if (!project?.id) return;
     // The workflow list is rendered below (needs the rows); the other tiles only need
@@ -241,28 +240,11 @@ export function OverviewScreen({ project, onNav, onDeleteProject }: { project: a
   ];
   return (
     <div className="scroll-y" style={{ flex: 1, padding: "24px 28px" }}>
-      <div className="fade-up" style={{ maxWidth: 1080, margin: "0 auto" }}>
+      <div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>
         <div className="row spread" style={{ marginBottom: 14 }}>
           <div>
             <div className="t-display">{project?.name}</div>
             <div className="fg-1" style={{ marginTop: 3 }}>Visual agent workspace · {project?.slug}</div>
-          </div>
-          <div className="row gap2">
-            <button className="btn btn-secondary" onClick={() => onNav("tools")}><Icon name="tools" size={15} />Tools</button>
-            {onDeleteProject && project?.id && (
-              <button
-                className="btn btn-danger"
-                disabled={deleting}
-                onClick={async () => {
-                  setDeleting(true);
-                  try { await onDeleteProject({ id: project.id, name: project.name }); }
-                  finally { setDeleting(false); }
-                }}
-              >
-                <Icon name="trash" size={15} />{deleting ? "Deleting..." : "Delete"}
-              </button>
-            )}
-            <button className="btn btn-primary" onClick={() => onNav("workflow-canvas")}><Icon name="workflows" size={15} />Open canvas</button>
           </div>
         </div>
         <div style={{ marginBottom: 18 }}>

--- a/apps/web/components/screens/knowledge.tsx
+++ b/apps/web/components/screens/knowledge.tsx
@@ -59,7 +59,7 @@ export function KnowledgeScreen({ project }: { project: any }) {
           ))}
         </nav>
         <div className="scroll-y" style={{ flex: 1, minWidth: 0, padding: "4px 28px 24px 16px" }}>
-          <div style={{ maxWidth: 960 }}>
+          <div style={{ maxWidth: 1400 }}>
             {tab === "files" && <Files project={project} />}
             {tab === "qa" && <QA project={project} />}
             {tab === "search" && <SearchDebugger project={project} />}

--- a/apps/web/components/screens/mcp.tsx
+++ b/apps/web/components/screens/mcp.tsx
@@ -97,7 +97,7 @@ function ServerDetail({ project, server, onChanged, cached, onLoaded }: { projec
   const enabledCount = tools ? tools.filter((t) => !disabled.has(t.name)).length : 0;
 
   return (
-    <div style={{ maxWidth: 720 }}>
+    <div style={{ maxWidth: 960 }}>
       <div className="row spread" style={{ marginBottom: 18 }}>
         <div className="row gap3">
           <Tile icon="connect" color="var(--accent)" size={40} glow />

--- a/apps/web/components/screens/platform.tsx
+++ b/apps/web/components/screens/platform.tsx
@@ -53,7 +53,7 @@ function Header({ title, subtitle, action }: { title: string; subtitle?: string;
 }
 
 function Shell({ children }: { children: React.ReactNode }) {
-  return <div className="scroll-y" style={{ flex: 1, padding: "24px 28px" }}><div className="fade-up" style={{ maxWidth: 980, margin: "0 auto" }}>{children}</div></div>;
+  return <div className="scroll-y" style={{ flex: 1, padding: "24px 28px" }}><div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>{children}</div></div>;
 }
 
 function useWorkflows(pid?: string) {

--- a/apps/web/components/screens/settings.tsx
+++ b/apps/web/components/screens/settings.tsx
@@ -5,7 +5,7 @@
    Model Pricing and Secrets manage their own persistence. */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "../icons";
-import { EmptyState, Field, Modal, Segmented, Toggle } from "../primitives";
+import { EmptyState, Field, Modal, Segmented, Tabs, Toggle } from "../primitives";
 import { api, clearTokens, InviteResult, MeResult, ProjectVersion, Secret, TeamMember } from "@/lib/api";
 import { MODELS } from "@/lib/data";
 
@@ -57,7 +57,7 @@ const HISTORY_TABS: SectionId[] = ["general", "budgets", "knowledge", "versionin
 // Field paths whose values must never be shown in a diff (secrets / credentials).
 const MASK_RE = /credential|secret|token|api[_-]?key|password/i;
 
-export function SettingsScreen({ project }: { project: any }) {
+export function SettingsScreen({ project, onDeleteProject }: { project: any; onDeleteProject?: (project: { id: string; name: string }) => Promise<void> | void }) {
   const [section, setSection] = useState<SectionId>("general");
   const [config, setConfig] = useState<Record<string, any>>({});
   const [meta, setMeta] = useState<{ name: string; description: string }>({ name: "", description: "" });
@@ -67,6 +67,8 @@ export function SettingsScreen({ project }: { project: any }) {
   const [secForm, setSecForm] = useState({ name: "", value: "", kind: "api_key" });
   const [pkeys, setPkeys] = useState<Record<string, string>>({});
   const [keySave, setKeySave] = useState<"idle" | "saving" | "saved">("idle");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const reloadSecrets = useCallback(() => { if (project?.id) api.listSecrets(project.id).then(setSecrets).catch(() => {}); }, [project?.id]);
   useEffect(() => {
@@ -149,7 +151,7 @@ export function SettingsScreen({ project }: { project: any }) {
 
         {/* content */}
         <div className="scroll-y grow" style={{ minWidth: 0 }}>
-          <div className="fade-up" style={{ maxWidth: 720, margin: "0 auto", padding: "24px 28px" }}>
+          <div className="fade-up" style={{ maxWidth: 960, margin: "0 auto", padding: "24px 28px" }}>
             <div className="row spread" style={{ marginBottom: 18 }}>
               <div className="t-display">{activeMeta.label}</div>
               {activeMeta.savesConfig && (
@@ -318,6 +320,28 @@ export function SettingsScreen({ project }: { project: any }) {
                     </label>
                   ))}
                 </Card>
+                {onDeleteProject && project?.id && (
+                  <div className="card" style={{ padding: 18, marginBottom: 16, borderColor: "var(--err)" }}>
+                    <div className="row spread" style={{ marginBottom: 12 }}><div className="t-h2" style={{ color: "var(--err)" }}>Danger zone</div></div>
+                    <div className="field-help" style={{ marginTop: 0, marginBottom: 12 }}>Deleting this project removes its workflows, agents, tools, auth providers, knowledge, secrets, runs, and traces. This cannot be undone.</div>
+                    {!confirmDelete ? (
+                      <button className="btn btn-danger btn-sm" onClick={() => setConfirmDelete(true)}><Icon name="trash" size={14} />Delete project</button>
+                    ) : (
+                      <div className="row gap2 wrap" style={{ alignItems: "center" }}>
+                        <span className="t-body-sm">Permanently delete <b>{project.name}</b>?</span>
+                        <button className="btn btn-danger btn-sm" disabled={deleting}
+                          onClick={async () => {
+                            setDeleting(true);
+                            try { await onDeleteProject({ id: project.id, name: project.name }); }
+                            finally { setDeleting(false); setConfirmDelete(false); }
+                          }}>
+                          <Icon name="trash" size={14} />{deleting ? "Deleting…" : "Confirm delete"}
+                        </button>
+                        <button className="btn btn-ghost btn-sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</button>
+                      </div>
+                    )}
+                  </div>
+                )}
               </>
             )}
 
@@ -396,14 +420,12 @@ function SettingsHistory({ project }: { project: any }) {
   return (
     <div className="col" style={{ gap: 14 }}>
       <div className="field-help" style={{ marginTop: 0 }}>A read-only log of what changed in each settings section, newest first — captured on every save. Pick a section:</div>
-      <div className="row" style={{ gap: 6, flexWrap: "wrap" }}>
-        {HISTORY_TABS.map((id) => {
-          const meta = SECTIONS.find((s) => s.id === id)!;
-          return (
-            <button key={id} onClick={() => setTab(id)} className={"btn btn-sm " + (tab === id ? "btn-primary" : "btn-secondary")}>{meta.label}</button>
-          );
-        })}
-      </div>
+      <Tabs
+        equal
+        tabs={HISTORY_TABS.map((id) => ({ value: id, label: SECTIONS.find((s) => s.id === id)!.label }))}
+        value={tab}
+        onChange={(v) => setTab(v as SectionId)}
+      />
       {err && <div className="card" style={{ padding: 12, color: "var(--err)" }}>{err}</div>}
       {!err && versions === null && <div className="fg-2 t-caption">Loading history…</div>}
       {!err && versions !== null && forTab.length === 0 && (

--- a/apps/web/components/screens/tools.tsx
+++ b/apps/web/components/screens/tools.tsx
@@ -1,7 +1,7 @@
 "use client";
 /* Tools list (card grid) + Tool Builder (tabbed config + Live response token-meter signature). */
 import * as jmespath from "jmespath";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../icons";
 import { Field, Modal, Segmented, StatusPill, Tabs, Tile, TokenMeter, Toggle } from "../primitives";
 import { VersionHistory } from "../version-history";
@@ -57,7 +57,7 @@ export function ToolsScreen({ project, onOpen }: { project: any; onOpen: (t: Too
 
   return (
     <div className="scroll-y" style={{ flex: 1, padding: "22px 28px" }}>
-      <div className="fade-up" style={{ maxWidth: 1120, margin: "0 auto" }}>
+      <div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>
         <div className="row spread" style={{ marginBottom: 18 }}>
           <div>
             <div className="t-display" style={{ fontSize: 21 }}>Tools</div>
@@ -118,12 +118,10 @@ function ToolCard({ t, onOpen, onDelete, onDuplicate, onToggle }: { t: Tool; onO
   return (
     <div className="card card-hover" style={{ padding: 15, opacity: t.enabled ? 1 : 0.6 }} onClick={onOpen}>
       <div className="row spread" style={{ marginBottom: 10 }}>
-        <div className="row gap2"><Tile icon={KIND_ICON[t.kind] || "k_rest"} color="var(--accent)" size={34} /><span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span></div>
+        <span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span>
         <div className="row gap2" style={{ alignItems: "center" }}>
           <StatusPill status={t.last_tested || "untested"} />
-          <Toggle on={t.enabled} onChange={onToggle} />
-          <button className="iconbtn" title="Duplicate tool" onClick={onDuplicate}><Icon name="copy" size={14} /></button>
-          <button className="iconbtn" title="Delete tool" onClick={onDelete}><Icon name="trash" size={14} /></button>
+          <ToolCardMenu enabled={t.enabled} onToggle={onToggle} onDuplicate={onDuplicate} onDelete={onDelete} />
         </div>
       </div>
       <div className="mono" style={{ fontWeight: 600, fontSize: 13.5, color: "var(--fg-0)", overflowWrap: "anywhere", wordBreak: "break-word" }}>{t.name}</div>
@@ -133,6 +131,36 @@ function ToolCard({ t, onOpen, onDelete, onDuplicate, onToggle }: { t: Tool; onO
         <span className="row gap1"><Icon name={proj ? "check" : "minus"} size={12} />{proj ? "Response projection set" : "No projection"}</span>
         {t.auth_provider_id && <span className="row gap1 truncate" style={{ maxWidth: 130 }}><Icon name="auth" size={11} />{t.auth_provider_id.slice(0, 10)}</span>}
       </div>
+    </div>
+  );
+}
+
+/* Overflow menu on each tool card - enable/disable toggle, duplicate, delete.
+   Drops DOWN from the trigger, right-aligned so it never runs off-screen. */
+function ToolCardMenu({ enabled, onToggle, onDuplicate, onDelete }: { enabled: boolean; onToggle: () => void; onDuplicate: (e: React.MouseEvent) => void; onDelete: (e: React.MouseEvent) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
+    window.addEventListener("mousedown", h);
+    return () => window.removeEventListener("mousedown", h);
+  }, [open]);
+  const item: React.CSSProperties = { display: "flex", alignItems: "center", gap: 9, width: "100%", textAlign: "left", padding: "7px 9px", border: "none", background: "none", cursor: "pointer", borderRadius: 6, fontSize: 12.5, fontFamily: "var(--font-ui)" };
+  return (
+    <div ref={ref} style={{ position: "relative" }} onClick={(e) => e.stopPropagation()}>
+      <button className={"iconbtn" + (open ? " active" : "")} title="More actions" aria-haspopup="menu" aria-expanded={open} onClick={() => setOpen((o) => !o)}><Icon name="more" size={16} /></button>
+      {open && (
+        <div className="card fade-in" role="menu" style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, zIndex: 6000, minWidth: 172, padding: 4, boxShadow: "var(--sh-pop)" }}>
+          <div style={{ ...item, justifyContent: "space-between", color: "var(--fg-1)", cursor: "default" }}>
+            <span className="row gap2"><Icon name="bolt" size={15} style={{ color: enabled ? "var(--signal)" : "var(--fg-2)" }} />{enabled ? "Enabled" : "Disabled"}</span>
+            <Toggle on={enabled} onChange={onToggle} />
+          </div>
+          <div className="divider" style={{ margin: "4px 0" }} />
+          <button role="menuitem" style={{ ...item, color: "var(--fg-1)" }} onClick={(e) => { setOpen(false); onDuplicate(e); }}><Icon name="copy" size={15} />Duplicate</button>
+          <button role="menuitem" style={{ ...item, color: "var(--err)" }} onClick={(e) => { setOpen(false); onDelete(e); }}><Icon name="trash" size={15} />Delete</button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/screens/traces.tsx
+++ b/apps/web/components/screens/traces.tsx
@@ -209,7 +209,7 @@ function ConversationView({ project, detail }: { project: any; detail: Conversat
   };
 
   return (
-    <div className="fade-up col" style={{ maxWidth: 900, margin: "0 auto", gap: 4 }}>
+    <div className="fade-up col" style={{ maxWidth: 1100, margin: "0 auto", gap: 4 }}>
       {/* high-level rollup */}
       <div className="card" style={{ padding: "14px 18px", marginBottom: 12, borderLeft: "3px solid var(--accent)" }}>
         <div className="row spread">

--- a/apps/web/components/screens/workflows.tsx
+++ b/apps/web/components/screens/workflows.tsx
@@ -165,7 +165,7 @@ export function WorkflowsScreen({ project, onOpen }: { project: any; onOpen: (w:
 
   return (
     <div className="scroll-y" style={{ flex: 1, padding: "24px 28px" }}>
-      <div className="fade-up" style={{ maxWidth: 1000, margin: "0 auto" }}>
+      <div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>
         <div className="row spread" style={{ marginBottom: 18 }}>
           <div>
             <div className="t-display">Workflows</div>

--- a/apps/web/components/shell.tsx
+++ b/apps/web/components/shell.tsx
@@ -2,7 +2,7 @@
 /* Forge app shell: topbar, project sidebar, command palette, assistant. */
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "./icons";
-import { Avatar, Tile, StatusPill } from "./primitives";
+import { Avatar, Tile } from "./primitives";
 import { PROJECT_NAV, NavLeaf } from "@/lib/data";
 import { Markdown } from "./markdown";
 
@@ -115,30 +115,29 @@ export function ProjectSidebar({ project, active, onNav, onBack, refreshKey }: {
     const timer = window.setInterval(refresh, 15_000);
     return () => { live = false; window.clearInterval(timer); };
   }, [project?.id, refreshKey, countsBump]);
-  return (
-    <div style={{ width: 224, flex: "none", background: "var(--bg-1)", borderRight: "1px solid var(--line)", display: "flex", flexDirection: "column" }}>
-      <button onClick={onBack} className="row gap2" style={{ padding: "12px 14px 10px", background: "none", border: "none", borderBottom: "1px solid var(--line)", cursor: "pointer", textAlign: "left" }}>
-        <Tile icon="layers" color="var(--accent)" size={32} />
-        <div className="col" style={{ minWidth: 0, flex: 1 }}>
-          <div className="t-h2 truncate">{project?.name}</div>
-          <div className="fg-2 t-caption row gap1"><StatusPill status={project?.status || "active"} /></div>
-        </div>
-        <Icon name="chevdown" size={15} style={{ color: "var(--fg-2)" }} />
+  const renderLeaf = (n: NavLeaf) => {
+    const on = active === n.id;
+    const count = n.countKey ? counts[n.countKey] : undefined;
+    return (
+      <button key={n.id} onClick={() => onNav(n.id)} title={n.help || n.label} className={"sidenav-item" + (on ? " active" : "")}
+        style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", height: 34, padding: "0 10px", marginBottom: 1, borderRadius: 7, border: "none", cursor: "pointer", textAlign: "left", color: on ? "var(--accent)" : "var(--fg-1)", fontSize: 13, fontWeight: on ? 600 : 500, fontFamily: "var(--font-ui)", transition: "color var(--dur-fast)" }}>
+        <Icon name={n.icon} size={17} style={{ flex: "none" }} />
+        <span className="grow truncate">{n.label}</span>
+        {count != null && count > 0 && <span className="badge" style={on ? { background: "var(--accent-glow)", color: "var(--accent)" } : {}}>{count}</span>}
       </button>
-      <nav className="scroll-y" style={{ flex: 1, padding: 8 }}>
+    );
+  };
+  // Settings is pinned to the bottom (rendered in the footer below), so drop it from the scroll list.
+  const settingsLeaf = PROJECT_NAV.find((e): e is NavLeaf => "id" in e && e.id === "settings");
+  return (
+    <div style={{ width: 224, flex: "none", background: "var(--bg-1)", borderRight: "1px solid var(--line)", display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <button onClick={onBack} className="row gap2" style={{ height: 52, flex: "none", padding: "0 14px", background: "none", border: "none", borderBottom: "1px solid var(--line)", cursor: "pointer", textAlign: "left", alignItems: "center" }}>
+        <div className="t-h2 truncate" style={{ minWidth: 0, flex: 1 }}>{project?.name}</div>
+        <Icon name="chevdown" size={15} style={{ color: "var(--fg-2)", flex: "none" }} />
+      </button>
+      <nav className="scroll-y" style={{ flex: 1, minHeight: 0, padding: 8 }}>
         {PROJECT_NAV.map((entry, idx) => {
-          const renderLeaf = (n: NavLeaf) => {
-            const on = active === n.id;
-            const count = n.countKey ? counts[n.countKey] : undefined;
-            return (
-              <button key={n.id} onClick={() => onNav(n.id)} title={n.help || n.label} className={"sidenav-item" + (on ? " active" : "")}
-                style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", height: 34, padding: "0 10px", marginBottom: 1, borderRadius: 7, border: "none", cursor: "pointer", textAlign: "left", color: on ? "var(--accent)" : "var(--fg-1)", fontSize: 13, fontWeight: on ? 600 : 500, fontFamily: "var(--font-ui)", transition: "color var(--dur-fast)" }}>
-                <Icon name={n.icon} size={17} style={{ flex: "none" }} />
-                <span className="grow truncate">{n.label}</span>
-                {count != null && count > 0 && <span className="badge" style={on ? { background: "var(--accent-glow)", color: "var(--accent)" } : {}}>{count}</span>}
-              </button>
-            );
-          };
+          if ("id" in entry && entry.id === "settings") return null; // pinned to the footer
           if ("section" in entry) {
             const open = !collapsed[entry.section];
             return (
@@ -155,6 +154,13 @@ export function ProjectSidebar({ project, active, onNav, onBack, refreshKey }: {
           return renderLeaf(entry);
         })}
       </nav>
+      {/* Settings pinned to the bottom: sits above the scrolling nav (z-index + solid bg + top
+          shadow) so nav items scroll behind it on short viewports. */}
+      {settingsLeaf && (
+        <div style={{ flex: "none", position: "relative", zIndex: 2, padding: 8, borderTop: "1px solid var(--line)", background: "var(--bg-1)", boxShadow: "0 -6px 12px -8px rgba(0,0,0,.18)" }}>
+          {renderLeaf(settingsLeaf)}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Increase content max-widths across screens (dashboard, overview, agents, workflows, auth, mcp, deploy, embed, knowledge, traces, platform, settings) for a roomier layout.
- Sidebar: pin Settings to the footer and simplify the project header.
- Move project deletion out of the Overview header into a Settings "Danger zone" with an inline confirm step.
- Tabs: add an `equal` (equal-width) option; use it for settings history.
- Tools grid card: drop the redundant kind icon (the REST/type chip is enough) and collapse enable/duplicate/delete into a "..." overflow menu that drops down from the trigger.

<!-- Thanks for contributing to Forge! Please fill this out to speed up review. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link the issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance
- [ ] Refactor (no behavior change)
- [ ] Docs / chore

## Checklist

- [ ] Backend: `ruff check forge migrations` is clean and `pytest -q` passes (from `apps/api`)
- [ ] New/changed backend code is `mypy`-clean
- [ ] Frontend: `pnpm --filter web build` passes (from repo root)
- [ ] Shared schemas (`packages/schemas`) updated if node/tool config changed
- [ ] Tests added/updated for the change (characterization test for behavior-preserving refactors)
- [ ] `CHANGELOG.md` updated under **Unreleased** (for user-facing changes)
- [ ] No secrets, tokens, or customer data in the diff

## Notes for reviewers

<!-- Anything that needs special attention, screenshots for UI changes, migration notes, etc. -->
