### PR TITLE
feat: tool sets + per-project MCP server (API key, PAT, OAuth 2.1)

### DIFF
--- a/apps/api/forge/config.py
+++ b/apps/api/forge/config.py
@@ -148,6 +148,11 @@ class Settings(BaseSettings):
     # Public URL of the web console (where the SPA is served). Used to build invite links
     # emailed to new teammates, e.g. https://app.forge.yourco.com.
     public_console_url: str = "http://localhost:3000"
+    # Expose Forge's MCP server as an OAuth 2.1 resource + authorization server (MCP authorization
+    # spec). OFF by default: the /.well-known discovery, register/authorize/token endpoints, and the
+    # OAuth 401 challenge are only served when enabled, so an operator opts in AFTER reviewing the
+    # flow (consent UX, registered-client trust, MFA/multi-workspace login edge cases).
+    mcp_oauth_enabled: bool = False
 
     # --- Outbound email (SMTP) - used for team invites & notifications. When smtp_host is
     # unset, email sending is a no-op and the API returns the invite link so an admin can

--- a/apps/api/forge/db/base.py
+++ b/apps/api/forge/db/base.py
@@ -92,6 +92,8 @@ def _ensure_new_columns(conn) -> None:
         "triggers": {"metadata": "JSON DEFAULT '{}'"},
         "agents": {"created_by": "VARCHAR(36)", "created_by_email": "VARCHAR(320)"},
         "mcp_clients": {"disabled_tools": "JSON DEFAULT '[]'"},
+        "api_keys": {"user_id": "VARCHAR(36)", "project_id": "VARCHAR(36)"},
+        "tool_sets": {"exposed": "BOOLEAN NOT NULL DEFAULT 1"},
         "projects": {"embed_key": "VARCHAR(64)"},
         "spans": {"input": "JSON", "output": "JSON"},
         "runs": {"source": "VARCHAR(40) NOT NULL DEFAULT 'playground'"},

--- a/apps/api/forge/engine/context.py
+++ b/apps/api/forge/engine/context.py
@@ -41,6 +41,11 @@ class CompileContext:
     # agent via config["components"], the same way tools are (Feature 2 - generative UI).
     component_registry: dict[str, Any] = field(default_factory=dict)
 
+    # Tool-set membership (tool_set_id -> [tool_id, ...]) for the project, populated by the
+    # runtime assembler. Lets an agent be granted a whole set via config.toolsets and have it
+    # resolve to the set's member tools at compile time (see resolve_tool_ids).
+    toolset_members: dict[str, list[str]] = field(default_factory=dict)
+
     # Cross-cutting services.
     auth_resolver: Any = None
     sandbox: Any = None
@@ -93,6 +98,23 @@ class CompileContext:
             tool = self.tool_registry.get(i)
             if tool is not None:
                 out.append(tool)
+        return out
+
+    def resolve_tool_ids(self, tool_ids: Sequence[str] | None, set_ids: Sequence[str] | None = None) -> list[str]:
+        """Combine explicit tool ids with the members of any referenced tool sets into one
+        order-stable, de-duplicated id list. Unknown set ids contribute nothing (tolerant,
+        like tools_for), so an agent can be granted individual tools AND whole sets at once."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for tid in tool_ids or []:
+            if tid not in seen:
+                seen.add(tid)
+                out.append(tid)
+        for sid in set_ids or []:
+            for tid in self.toolset_members.get(sid, []):
+                if tid not in seen:
+                    seen.add(tid)
+                    out.append(tid)
         return out
 
     def components_for(self, ids: Sequence[str]) -> list[Any]:

--- a/apps/api/forge/main.py
+++ b/apps/api/forge/main.py
@@ -37,7 +37,9 @@ from forge.routers import (
     hooks,
     knowledge,
     mcp_clients,
+    mcp_oauth,
     mcp_server,
+    mcp_tokens,
     nodes,
     oauth,
     pricing,
@@ -46,6 +48,7 @@ from forge.routers import (
     runs,
     secrets,
     stats,
+    tool_sets,
     tools,
     traces,
     versions,
@@ -256,10 +259,10 @@ def create_app() -> FastAPI:
         health.router, auth.router, auth.team_router, auth.workspace_router, auth.apikeys_router,
         audit.router, oauth.router, hooks.router,
         nodes.router, projects.router, workflows.router, runs.router, project_run.router,
-        tools.router, components.router, embed.router, embed_public.router, auth_providers.router, secrets.router, agents.router,
+        tool_sets.router, tools.router, components.router, embed.router, embed_public.router, auth_providers.router, secrets.router, agents.router,
         knowledge.router, knowledge.qa_router, traces.router, conversations.router, assistant.router, stats.router,
         triggers_router.router, channels.router, channels.public, handoff.router, evals.router,
-        pricing.router, mcp_server.router, mcp_clients.router, versions.router,
+        pricing.router, mcp_oauth.router, mcp_server.router, mcp_tokens.router, mcp_clients.router, versions.router,
     ):
         app.include_router(r)
     return app

--- a/apps/api/forge/models/__init__.py
+++ b/apps/api/forge/models/__init__.py
@@ -13,6 +13,7 @@ from forge.models.entities import (
     McpClient,
     Memory,
     ModelPrice,
+    OAuthClient,
     Project,
     QaPair,
     Run,
@@ -21,6 +22,8 @@ from forge.models.entities import (
     Tenant,
     Thread,
     Tool,
+    ToolSet,
+    ToolSetMember,
     Trace,
     Trigger,
     User,
@@ -33,7 +36,7 @@ from forge.models.evals import EvalResult, EvalRun
 
 __all__ = [
     "Tenant", "User", "Project", "Workflow", "Thread", "Run", "Trace", "Span",
-    "Tool", "AuthProvider", "Secret", "McpClient", "Agent", "KbSource", "QaPair",
+    "Tool", "ToolSet", "ToolSetMember", "AuthProvider", "Secret", "McpClient", "Agent", "KbSource", "QaPair",
     "AuditLog", "Trigger", "Channel", "Component", "HandoffRequest", "Dataset", "ModelPrice", "Memory",
-    "EntityVersion", "EvalRun", "EvalResult",
+    "EntityVersion", "EvalRun", "EvalResult", "OAuthClient",
 ]

--- a/apps/api/forge/models/entities.py
+++ b/apps/api/forge/models/entities.py
@@ -42,7 +42,7 @@ class User(PkTimestamp, Base):
     tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), index=True)
     email: Mapped[str] = mapped_column(String(320), index=True)
     password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    role: Mapped[str] = mapped_column(String(30), default="owner")  # owner|admin|editor|viewer
+    role: Mapped[str] = mapped_column(String(30), default="owner")  # owner|admin|editor|viewer|connector
     status: Mapped[str] = mapped_column(String(20), default="active")
     last_login_at: Mapped[datetime | None] = mapped_column(nullable=True)
 
@@ -84,6 +84,42 @@ class Tool(PkTimestamp, Base):
     auth_provider_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     last_tested: Mapped[str | None] = mapped_column(String(20), nullable=True)  # pass|fail|untested
+
+
+class ToolSet(PkTimestamp, Base):
+    """A named, describable group of tools ("tool set"). Tool sets are the unit of
+    organization in the Tools screen (they render as folders) AND the unit of exposure: an
+    agent can be granted a whole set (agent config.toolsets) and the MCP server can publish
+    a set as a GitHub-style toolset. Membership is many-to-many via ToolSetMember, so a tool
+    may live in several sets (label-style, not a single home folder). `description` is what
+    an MCP client / the model reads to decide when to enable the set; `is_default` marks a
+    set that's published by default when a project exposes its tools over MCP."""
+
+    __tablename__ = "tool_sets"
+    __table_args__ = (UniqueConstraint("tenant_id", "project_id", "slug", name="uq_tool_set_slug"),)
+    tenant_id: Mapped[str] = mapped_column(String(36), index=True)
+    project_id: Mapped[str] = mapped_column(String(36), index=True)
+    name: Mapped[str] = mapped_column(String(120))
+    slug: Mapped[str] = mapped_column(String(120), index=True)  # url-safe id, unique per project
+    description: Mapped[str] = mapped_column(Text, default="")
+    icon: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Publish this set (and its enabled tools) over MCP. The MCP surface is EXACTLY the enabled
+    # tools of exposed sets - there are no loose "directly exposed" tools (GitHub-toolset model).
+    exposed: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+class ToolSetMember(PkTimestamp, Base):
+    """Many-to-many membership linking a Tool to a ToolSet (a tool can belong to several
+    sets). No DB-level cascade (matching the rest of the schema); ToolSetService and
+    ToolService delete the membership rows explicitly when a set or tool is removed."""
+
+    __tablename__ = "tool_set_members"
+    __table_args__ = (UniqueConstraint("tool_set_id", "tool_id", name="uq_tool_set_member"),)
+    tenant_id: Mapped[str] = mapped_column(String(36), index=True)
+    project_id: Mapped[str] = mapped_column(String(36), index=True)
+    tool_set_id: Mapped[str] = mapped_column(String(36), index=True)
+    tool_id: Mapped[str] = mapped_column(String(36), index=True)
 
 
 class Component(PkTimestamp, Base):
@@ -437,6 +473,12 @@ class ApiKey(PkTimestamp, Base):
     last_used_at: Mapped[datetime | None] = mapped_column(nullable=True)
     expires_at: Mapped[datetime | None] = mapped_column(nullable=True)  # optional hard expiry
     created_by: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    # Personal access token (MCP): when `user_id` is set this row is a per-user PAT (plaintext
+    # prefix forge_pat_, minted by ApiKeyService.create_personal) used to authenticate an
+    # individual over a project's MCP server AS an end_user, optionally scoped to one `project_id`.
+    # A PAT is deliberately NOT a general-API principal - get_current_user only honors forge_sk_.
+    user_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    project_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
 
 class ProjectMember(PkTimestamp, Base):
@@ -450,6 +492,19 @@ class ProjectMember(PkTimestamp, Base):
     project_id: Mapped[str] = mapped_column(String(36), index=True)
     user_id: Mapped[str] = mapped_column(String(36), index=True)
     role: Mapped[str] = mapped_column(String(30), default="viewer")  # owner|admin|editor|viewer
+
+
+class OAuthClient(PkTimestamp, Base):
+    """A dynamically-registered OAuth 2.1 client (RFC 7591) for the MCP authorization server.
+    Public clients (no secret), identified by `client_id` with an exact-match redirect_uri
+    allow-list. Registered open / pre-auth (any MCP client may register); the USER identity is
+    established later at the authorize step. Global (no tenant_id) - it is a client registry, not
+    tenant data. Only used when settings.mcp_oauth_enabled is on."""
+
+    __tablename__ = "oauth_clients"
+    client_id: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    client_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    redirect_uris: Mapped[list] = mapped_column(JSON, default=list)
 
 
 class UserSecurity(PkTimestamp, Base):

--- a/apps/api/forge/nodes/agent_node.py
+++ b/apps/api/forge/nodes/agent_node.py
@@ -99,8 +99,8 @@ def build_subagents(subagents_cfg: list[dict], ctx: CompileContext) -> list[dict
         spec: dict[str, Any] = {"name": sa["name"], "description": sa.get("description", "")}
         if sa.get("system_prompt"):
             spec["system_prompt"] = sa["system_prompt"]
-        if sa.get("tools"):
-            spec["tools"] = ctx.tools_for(sa["tools"])
+        if sa.get("tools") or sa.get("toolsets"):
+            spec["tools"] = ctx.tools_for(ctx.resolve_tool_ids(sa.get("tools"), sa.get("toolsets")))
         if sa.get("model"):
             spec["model"] = resolve_model(sa["model"], ctx)
         if sa.get("middleware"):
@@ -218,7 +218,7 @@ def _dynamic_field_middleware(config: dict, ctx: CompileContext, base_prompt: st
 
 
 def _common_kwargs(config: dict, ctx: CompileContext) -> dict:
-    tools = list(ctx.tools_for(config.get("tools", [])))
+    tools = list(ctx.tools_for(ctx.resolve_tool_ids(config.get("tools"), config.get("toolsets"))))
     # Built-in knowledge access (RAG / Q&A) attached straight to the agent via its
     # `knowledge` config - no separate Tool row needed (see tools/builtin.py).
     if config.get("knowledge"):

--- a/apps/api/forge/routers/auth_providers.py
+++ b/apps/api/forge/routers/auth_providers.py
@@ -7,7 +7,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from forge.deps import CurrentUser, current_tenant_id, get_session, require_role
 from forge.schemas.contracts import validate_against_id
-from forge.schemas.dto import AuthProviderCreate, AuthProviderOut, AuthProviderUpdate, AuthTestIn
+from forge.schemas.dto import (
+    AuthProviderCreate,
+    AuthProviderOut,
+    AuthProviderUpdate,
+    AuthTestIn,
+    UserConnectionIn,
+)
 from forge.services.auth_providers import AuthProviderService
 from forge.services.versions import safe_snapshot
 
@@ -75,3 +81,39 @@ async def test_ap(project_id: str, ap_id: str, body: AuthTestIn, session: AsyncS
     if ap is None:
         raise HTTPException(404, "Auth provider not found")
     return await AuthProviderService.test(tenant_id, project_id, ap, body.context)
+
+
+# --- Per-user connected credentials: the app owner's connect flow stores each end user's downstream
+# credential here (server-to-server, editor+), and the AuthResolver uses it to act as that user. ---
+@router.put("/{ap_id}/connections/{end_user_id}", status_code=204)
+async def set_user_connection(project_id: str, ap_id: str, end_user_id: str, body: UserConnectionIn,
+                              session: AsyncSession = Depends(get_session), tenant_id: str = Depends(current_tenant_id),
+                              _: CurrentUser = Depends(require_role("editor"))):
+    ap = await AuthProviderService.get(session, tenant_id, ap_id)
+    if ap is None:
+        raise HTTPException(404, "Auth provider not found")
+    bundle = {"access_token": body.access_token, **(body.extra or {})}
+    if body.refresh_token:
+        bundle["refresh_token"] = body.refresh_token
+    if body.expires_at is not None:
+        bundle["expires_at"] = body.expires_at
+    await AuthProviderService.set_user_connection(session, tenant_id, project_id, ap, end_user_id, bundle=bundle)
+
+
+@router.get("/{ap_id}/connections/{end_user_id}")
+async def get_user_connection(project_id: str, ap_id: str, end_user_id: str,
+                              session: AsyncSession = Depends(get_session), tenant_id: str = Depends(current_tenant_id)):
+    ap = await AuthProviderService.get(session, tenant_id, ap_id)
+    if ap is None:
+        raise HTTPException(404, "Auth provider not found")
+    return await AuthProviderService.get_user_connection(tenant_id, project_id, ap, end_user_id)
+
+
+@router.delete("/{ap_id}/connections/{end_user_id}", status_code=204)
+async def delete_user_connection(project_id: str, ap_id: str, end_user_id: str,
+                                 session: AsyncSession = Depends(get_session), tenant_id: str = Depends(current_tenant_id),
+                                 _: CurrentUser = Depends(require_role("editor"))):
+    ap = await AuthProviderService.get(session, tenant_id, ap_id)
+    if ap is None:
+        raise HTTPException(404, "Auth provider not found")
+    await AuthProviderService.clear_user_connection(session, tenant_id, project_id, ap, end_user_id)

--- a/apps/api/forge/routers/mcp_oauth.py
+++ b/apps/api/forge/routers/mcp_oauth.py
@@ -1,0 +1,317 @@
+"""OAuth 2.1 authorization + resource server for Forge's MCP endpoint (MCP authorization spec).
+
+Lets ANY standard MCP client (Claude Desktop, Cursor, VS Code) authenticate a user over
+`POST /v1/mcp/{project_id}` without a pre-shared key: the client discovers this server, registers
+dynamically (RFC 7591), runs an authorization-code + PKCE flow, and presents the resulting
+audience-bound access token as `Authorization: Bearer …`. The MCP router validates the token and
+acts AS that user (forge.routers.mcp_server._oauth_end_user).
+
+Standards implemented: OAuth 2.1 (authorization code + PKCE S256, public clients), Protected
+Resource Metadata (RFC 9728), Authorization Server Metadata (RFC 8414), Dynamic Client
+Registration (RFC 7591), and Resource Indicators (RFC 8707 - the token `aud` is the project's
+canonical MCP URL, so tokens can't be replayed at a different resource).
+
+GATED: everything here 404s unless `settings.mcp_oauth_enabled` is on, so an operator opts in after
+review. KNOWN REVIEW ITEMS (documented, intentionally conservative): the consent screen is a
+minimal server-rendered login form; MFA-enabled accounts are refused here (no MFA bypass) and must
+use a personal access token; there is no per-client consent memory. Harden these before relying on
+it in production.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import html as _html
+import secrets as _secrets
+import urllib.parse
+
+from fastapi import APIRouter, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from sqlalchemy import select
+
+from forge.config import settings
+from forge.db.base import SessionLocal
+from forge.models import OAuthClient
+from forge.security import (
+    TokenError,
+    create_mcp_access_token,
+    create_mcp_authorization_code,
+    create_mcp_refresh_token,
+    decode_token,
+    revoke,
+)
+from forge.services.auth import AuthError, AuthService
+from forge.util.ratelimit import rate_limiter
+
+router = APIRouter(tags=["mcp-oauth"])
+
+
+def _enabled() -> None:
+    if not settings.mcp_oauth_enabled:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "MCP OAuth is not enabled")
+
+
+def _base() -> str:
+    return settings.public_base_url.rstrip("/")
+
+
+def _valid_redirect(uri: str) -> bool:
+    """Only https, or a loopback address for native clients (open-redirect / spec hygiene)."""
+    try:
+        p = urllib.parse.urlparse(uri)
+    except ValueError:
+        return False
+    if p.scheme == "https":
+        return True
+    return p.scheme in ("http",) and p.hostname in ("localhost", "127.0.0.1", "::1")
+
+
+def _pkce_ok(verifier: str, challenge: str) -> bool:
+    digest = hashlib.sha256((verifier or "").encode()).digest()
+    computed = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return hmac.compare_digest(computed, challenge or "")
+
+
+async def _load_client(client_id: str | None) -> OAuthClient | None:
+    if not client_id:
+        return None
+    async with SessionLocal() as s:
+        return (await s.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))).scalar_one_or_none()
+
+
+def _oauth_error(error: str, description: str, status_code: int = 400) -> JSONResponse:
+    return JSONResponse({"error": error, "error_description": description}, status_code=status_code)
+
+
+# --- Discovery (RFC 8414 / RFC 9728) --------------------------------------------------------
+@router.get("/.well-known/oauth-authorization-server")
+async def authorization_server_metadata():
+    _enabled()
+    b = _base()
+    return {
+        "issuer": b,
+        "authorization_endpoint": f"{b}/v1/oauth/authorize",
+        "token_endpoint": f"{b}/v1/oauth/token",
+        "registration_endpoint": f"{b}/v1/oauth/register",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+    }
+
+
+@router.get("/.well-known/oauth-protected-resource/v1/mcp/{project_id}")
+async def protected_resource_metadata(project_id: str):
+    _enabled()
+    b = _base()
+    return {"resource": f"{b}/v1/mcp/{project_id}", "authorization_servers": [b]}
+
+
+# --- Dynamic client registration (RFC 7591) -------------------------------------------------
+@router.post("/v1/oauth/register", status_code=201)
+async def register_client(body: dict):
+    _enabled()
+    redirect_uris = body.get("redirect_uris") or []
+    if not isinstance(redirect_uris, list) or not redirect_uris:
+        return _oauth_error("invalid_client_metadata", "redirect_uris is required")
+    if not all(isinstance(u, str) and _valid_redirect(u) for u in redirect_uris):
+        return _oauth_error("invalid_redirect_uri", "redirect_uris must be https or loopback http")
+    client_id = "mcp_" + _secrets.token_urlsafe(24)
+    name = str(body.get("client_name"))[:200] if body.get("client_name") else None
+    async with SessionLocal() as s:
+        s.add(OAuthClient(client_id=client_id, client_name=name, redirect_uris=redirect_uris))
+        await s.commit()
+    return {
+        "client_id": client_id,
+        "client_name": name,
+        "redirect_uris": redirect_uris,
+        "token_endpoint_auth_method": "none",
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+    }
+
+
+# --- Authorization endpoint (code + PKCE) ---------------------------------------------------
+# Branded consent page - mirrors the console's login card (Forge wordmark, accent-orange
+# button, card on a tinted background) so the OAuth login reads as Forge, while staying a
+# self-contained server-rendered page (the authorization server can't depend on the SPA).
+# Uses %%…%% sentinels (not str.format/f-string) so the CSS braces need no escaping. Every
+# injected value is HTML-escaped; HIDDEN/ERR are substituted before NAME so a sentinel-looking
+# client name can't be re-substituted (str.replace is single-pass, non-recursive).
+_CONSENT_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Authorize %%NAME%% · Forge</title>
+<style>
+  :root{--bg:#F6F7F9;--card:#FFFFFF;--line:#E2E6EC;--fg:#11161C;--fg2:#7A848F;--accent:#E8541F;--accent-dim:#B8420F;--err:#D23A34;}
+  @media (prefers-color-scheme:dark){:root{--bg:#0A0C0F;--card:#0F1318;--line:#2A323D;--fg:#EEF2F6;--fg2:#7A848F;--accent:#FF6A3D;--accent-dim:#C24E2B;--err:#F2615B;}}
+  *{box-sizing:border-box}
+  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;}
+  .card{width:380px;max-width:calc(100vw - 32px);background:var(--card);border:1px solid var(--line);border-radius:14px;padding:28px;box-shadow:0 12px 40px rgba(17,22,28,.12);}
+  .brand{font-size:22px;font-weight:700;letter-spacing:-.01em;margin:0 0 4px;}
+  .sub{color:var(--fg2);font-size:14px;line-height:1.5;margin:0 0 20px;}
+  .sub b{color:var(--fg);font-weight:600;}
+  label{display:block;margin-bottom:12px;}
+  .lbl{display:block;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--fg2);margin-bottom:6px;}
+  .lbl .hint{text-transform:none;letter-spacing:0;font-weight:400;}
+  input{width:100%;height:38px;padding:0 12px;font-size:14px;color:var(--fg);background:var(--card);border:1px solid var(--line);border-radius:8px;outline:none;}
+  input:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(232,84,31,.15);}
+  button{width:100%;height:40px;margin-top:6px;border:0;border-radius:8px;background:var(--accent);color:#fff;font-size:14px;font-weight:600;cursor:pointer;}
+  button:hover{background:var(--accent-dim);}
+  .err{color:var(--err);font-size:13px;margin-bottom:12px;}
+  .fieldhint{color:var(--fg2);font-size:12px;line-height:1.45;margin:-6px 0 14px;}
+</style></head>
+<body>
+<form class="card" method="post" action="/v1/oauth/authorize">
+  <div class="brand">Forge</div>
+  <div class="sub"><b>%%NAME%%</b> wants to access your Forge tools over MCP, acting as you.</div>
+  %%ERR%%
+  %%HIDDEN%%
+  <label><span class="lbl">Email</span><input name="email" type="email" required autocomplete="username"></label>
+  <label><span class="lbl">Password</span><input name="password" type="password" required autocomplete="current-password"></label>
+  <label><span class="lbl">Workspace id <span class="hint">(optional)</span></span><input name="workspace_id"></label>
+  <div class="fieldhint">Leave blank unless the same email is registered in multiple workspaces. It's your workspace ID (Settings &gt; General), not the project ID.</div>
+  <button type="submit">Authorize</button>
+</form>
+</body></html>"""
+
+
+def _consent_html(fields: dict, client: OAuthClient, error: str | None = None) -> str:
+    def h(v: object) -> str:
+        return _html.escape(str(v or ""))
+
+    hidden = "".join(
+        f'<input type="hidden" name="{h(k)}" value="{h(v)}">'
+        for k, v in fields.items()
+    )
+    err = f'<div class="err">{h(error)}</div>' if error else ""
+    name = h(client.client_name or client.client_id)
+    return (
+        _CONSENT_TEMPLATE
+        .replace("%%HIDDEN%%", hidden)
+        .replace("%%ERR%%", err)
+        .replace("%%NAME%%", name)
+    )
+
+
+def _authorize_fields(q: dict) -> dict:
+    return {
+        "client_id": q.get("client_id", ""),
+        "redirect_uri": q.get("redirect_uri", ""),
+        "code_challenge": q.get("code_challenge", ""),
+        "state": q.get("state", ""),
+        "resource": q.get("resource", ""),
+        "scope": q.get("scope", ""),
+    }
+
+
+@router.get("/v1/oauth/authorize", response_class=HTMLResponse)
+async def authorize_form(request: Request):
+    _enabled()
+    q = dict(request.query_params)
+    if q.get("response_type") != "code":
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "response_type must be 'code'")
+    if q.get("code_challenge_method") != "S256" or not q.get("code_challenge"):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "PKCE with code_challenge_method=S256 is required")
+    client = await _load_client(q.get("client_id"))
+    if client is None or q.get("redirect_uri") not in (client.redirect_uris or []):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "unknown client_id or unregistered redirect_uri")
+    return HTMLResponse(_consent_html(_authorize_fields(q), client))
+
+
+@router.post("/v1/oauth/authorize")
+async def authorize_submit(
+    request: Request,
+    email: str = Form(...),
+    password: str = Form(...),
+    workspace_id: str = Form(""),
+    client_id: str = Form(...),
+    redirect_uri: str = Form(...),
+    code_challenge: str = Form(...),
+    state: str = Form(""),
+    resource: str = Form(""),
+    scope: str = Form(""),
+):
+    _enabled()
+    fields = {"client_id": client_id, "redirect_uri": redirect_uri, "code_challenge": code_challenge,
+              "state": state, "resource": resource, "scope": scope}
+    client = await _load_client(client_id)
+    if client is None or redirect_uri not in (client.redirect_uris or []):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "unknown client_id or unregistered redirect_uri")
+    # Throttle the credential form per client IP (brute-force guard on this login surface).
+    ip = request.client.host if request.client else "?"
+    if not rate_limiter.allow(f"oauth_authorize:{ip}", rate=20, per=60):
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, "too many attempts, slow down")
+
+    async with SessionLocal() as s:
+        try:
+            user = await AuthService.authenticate(s, email=email, password=password, tenant_id=workspace_id or None)
+        except AuthError as e:
+            return HTMLResponse(_consent_html(fields, client, error=str(e)), status_code=401)
+        # No MFA bypass: an account with TOTP enabled must not authorize via this minimal form.
+        if await AuthService.totp_status(s, user.id):
+            return HTMLResponse(
+                _consent_html(fields, client, error="This account uses MFA; use a personal access token for MCP instead."),
+                status_code=401,
+            )
+
+    code = create_mcp_authorization_code(claims={
+        "sub": user.id, "tid": user.tenant_id, "role": user.role,
+        "cid": client_id, "ru": redirect_uri, "cc": code_challenge, "res": resource or "",
+    })
+    sep = "&" if "?" in redirect_uri else "?"
+    url = f"{redirect_uri}{sep}code={urllib.parse.quote(code)}"
+    if state:
+        url += f"&state={urllib.parse.quote(state)}"
+    return RedirectResponse(url, status_code=status.HTTP_302_FOUND)
+
+
+# --- Token endpoint -------------------------------------------------------------------------
+@router.post("/v1/oauth/token")
+async def token(
+    grant_type: str = Form(...),
+    code: str = Form(""),
+    redirect_uri: str = Form(""),
+    client_id: str = Form(""),
+    code_verifier: str = Form(""),
+    refresh_token: str = Form(""),
+):
+    _enabled()
+    if grant_type == "authorization_code":
+        try:
+            claims = decode_token(code, expected_type="mcp_auth_code")
+        except TokenError:
+            return _oauth_error("invalid_grant", "invalid or expired authorization code")
+        if claims.get("cid") != client_id or claims.get("ru") != redirect_uri:
+            return _oauth_error("invalid_grant", "client_id / redirect_uri mismatch")
+        if not _pkce_ok(code_verifier, claims.get("cc", "")):
+            return _oauth_error("invalid_grant", "PKCE verification failed")
+        # Single-use: burn the code's jti so a replayed authorization code is rejected (decode_token
+        # checks the revocation denylist). `exp` lets the entry self-prune.
+        revoke(claims.get("jti"), exp=claims.get("exp"))
+        resource = claims.get("res") or ""
+        access = create_mcp_access_token(claims={
+            "sub": claims["sub"], "tid": claims["tid"], "role": claims.get("role"),
+            "res": resource, "cid": client_id,
+        })
+        refresh = create_mcp_refresh_token(claims={
+            "sub": claims["sub"], "tid": claims["tid"], "role": claims.get("role"),
+            "cid": client_id, "res": resource,
+        })
+        return {"access_token": access, "token_type": "Bearer", "expires_in": 3600, "refresh_token": refresh, "scope": ""}
+
+    if grant_type == "refresh_token":
+        try:
+            claims = decode_token(refresh_token, expected_type="mcp_refresh")
+        except TokenError:
+            return _oauth_error("invalid_grant", "invalid refresh_token")
+        if client_id and claims.get("cid") != client_id:
+            return _oauth_error("invalid_grant", "client mismatch")
+        resource = claims.get("res") or ""
+        access = create_mcp_access_token(claims={
+            "sub": claims["sub"], "tid": claims["tid"], "role": claims.get("role"),
+            "res": resource, "cid": claims.get("cid"),
+        })
+        return {"access_token": access, "token_type": "Bearer", "expires_in": 3600, "scope": ""}
+
+    return _oauth_error("unsupported_grant_type", f"unsupported grant_type {grant_type!r}")

--- a/apps/api/forge/routers/mcp_server.py
+++ b/apps/api/forge/routers/mcp_server.py
@@ -5,6 +5,14 @@ MCP clients (Claude Desktop, Cursor, VS Code) can call a Forge project's tools. 
 per-project API key stored in `project.config.mcp_api_key` (required when set; open in the
 no-auth dev default). Full Streamable-HTTP/SSE transport is a future enhancement; this
 request/response JSON-RPC works with HTTP MCP clients.
+
+Tool sets ("toolsets", GitHub-MCP style): a project's tools can be published as named groups.
+  - Base endpoint  POST /v1/mcp/{project_id}            exposes the project's published surface
+    (project.config.mcp_published_toolsets: a list of set slugs, or "all"/"default"; unset =>
+    every enabled tool, the prior behavior).
+  - Per-set endpoint POST /v1/mcp/{project_id}/toolset/{slug} exposes ONLY that set's tools, so
+    a client can add one MCP server per toolset. The optional name allow-list
+    (project.config.mcp_exposed_tools) still applies as a further filter.
 """
 
 from __future__ import annotations
@@ -17,23 +25,17 @@ from sqlalchemy import select
 
 from forge.config import settings
 from forge.db.base import SessionLocal
-from forge.models import Project
+from forge.deps import run_context as parse_run_context
+from forge.models import Project, User
+from forge.security import TokenError, decode_token
+from forge.services.apikeys import ApiKeyService, looks_like_pat
 from forge.services.runtime import build_compile_context
+from forge.services.tool_sets import ToolSetService
 from forge.util.ratelimit import rate_limiter
 
 log = logging.getLogger("forge.routers.mcp_server")
 
 router = APIRouter(prefix="/v1/mcp", tags=["mcp-server"])
-
-
-def _exposed_tool_names(cfg: dict) -> set[str] | None:
-    """Optional per-project allow-list of tool names to expose over MCP (project.config
-    .mcp_exposed_tools). None => expose all enabled tools (prior behavior). Lets an operator
-    publish only safe tools instead of every tool incl. SQL/code."""
-    names = cfg.get("mcp_exposed_tools")
-    if isinstance(names, list) and names:
-        return {str(n) for n in names}
-    return None
 
 
 def _workflow_tool_name(cfg: dict) -> str | None:
@@ -43,6 +45,31 @@ def _workflow_tool_name(cfg: dict) -> str | None:
     if not cfg.get("mcp_expose_workflow"):
         return None
     return str(cfg.get("mcp_workflow_tool_name") or "run_workflow")
+
+
+def _exposed_names(ctx, sets: list, toolset_slug: str | None, excluded_ids: set[str]) -> set[str]:
+    """The flat set of tool NAMES to expose over MCP.
+
+    MCP has no "toolset" primitive - `tools/list` is a flat array - so tool sets are purely a
+    Forge-side grouping we flatten here. The surface is the enabled tools of EXPOSED sets, MINUS
+    any individually excluded tools: everything is published by default and the operator unticks
+    what they don't want (project.config.mcp_excluded_tools = tool ids). `ctx.tool_specs` holds only
+    ENABLED tools, so disabled tools drop out automatically. No loose/direct tools: a tool that
+    isn't in an exposed set is not published. `toolset_slug` scopes to that one set if exposed.
+    """
+    if toolset_slug:
+        chosen = [x for x in sets if x.slug == toolset_slug and x.exposed]
+    else:
+        chosen = [x for x in sets if x.exposed]
+    names: set[str] = set()
+    for st in chosen:
+        for tid in ctx.toolset_members.get(st.id, []):
+            if tid in excluded_ids:
+                continue
+            spec = ctx.tool_specs.get(tid)
+            if spec is not None:
+                names.add(spec["tool"].name)
+    return names
 
 
 def _bearer(request: Request) -> str | None:
@@ -59,6 +86,61 @@ async def _load_project(project_id: str) -> Project:
     return proj
 
 
+def _session_end_user(token: str | None, proj: Project) -> dict | None:
+    """The verified end_user carried by a Forge session token scoped to THIS project, or None.
+    Lets an MCP client authenticate as a specific end user (create_session_token) instead of the
+    shared project key, so entitlement gating and {{ctx.*}} injection act on their behalf."""
+    if not token:
+        return None
+    try:
+        claims = decode_token(token, expected_type="session")
+    except TokenError:
+        return None
+    if claims.get("pid") != proj.id or claims.get("tid") != proj.tenant_id:
+        return None
+    eu = claims.get("end_user")
+    return eu if isinstance(eu, dict) else None
+
+
+async def _pat_end_user(token: str | None, proj: Project) -> dict | None:
+    """The end_user for a per-user Personal Access Token (forge_pat_) presented to a project's MCP
+    server, or None. Lets an individual authenticate any MCP client with a pasteable token; the
+    acting identity is the token's owning user, scoped to the token's tenant (+ project if set)."""
+    if not token or not looks_like_pat(token):
+        return None
+    async with SessionLocal() as s:
+        key = await ApiKeyService.resolve_personal(s, token)
+        if key is None or key.tenant_id != proj.tenant_id:
+            return None
+        if key.project_id and key.project_id != proj.id:
+            return None
+        user = (await s.execute(select(User).where(User.id == key.user_id))).scalar_one_or_none()
+    if user is None or user.status != "active":
+        return None
+    return {"id": user.id, "email": user.email, "display_name": user.email, "roles": [user.role]}
+
+
+async def _oauth_end_user(token: str | None, proj: Project) -> dict | None:
+    """The end_user for a Forge-issued OAuth 2.1 MCP access token (see forge.routers.mcp_oauth),
+    or None. Validates the token's audience is THIS project's canonical MCP URL (RFC 8707) so a
+    token minted for another resource can't be replayed here. Only active when MCP OAuth is on."""
+    if not settings.mcp_oauth_enabled or not token:
+        return None
+    try:
+        claims = decode_token(token, expected_type="mcp_access")
+    except TokenError:
+        return None
+    canonical = f"{settings.public_base_url.rstrip('/')}/v1/mcp/{proj.id}"
+    res = claims.get("res") or ""  # resource binding (RFC 8707); a custom claim so the shared
+    if res != canonical and not res.startswith(canonical):  # JWT decoder doesn't reject on `aud`
+        return None
+    async with SessionLocal() as s:
+        user = (await s.execute(select(User).where(User.id == claims.get("sub")))).scalar_one_or_none()
+    if user is None or user.status != "active" or user.tenant_id != proj.tenant_id:
+        return None
+    return {"id": user.id, "email": user.email, "display_name": user.email, "roles": [user.role]}
+
+
 def _rpc(rid, result=None, error=None):
     out = {"jsonrpc": "2.0", "id": rid}
     if error is not None:
@@ -70,53 +152,98 @@ def _rpc(rid, result=None, error=None):
 
 @router.post("/{project_id}")
 async def mcp_rpc(project_id: str, request: Request):
+    """Base MCP endpoint: the project's published toolset surface (see module docstring)."""
+    return await _handle(project_id, request, toolset_slug=None)
+
+
+@router.post("/{project_id}/toolset/{slug}")
+async def mcp_rpc_toolset(project_id: str, slug: str, request: Request):
+    """Scoped MCP endpoint: exposes only the tools in tool set `slug` (GitHub-style toolset)."""
+    return await _handle(project_id, request, toolset_slug=slug)
+
+
+async def _handle(project_id: str, request: Request, *, toolset_slug: str | None):
     proj = await _load_project(project_id)
     cfg = proj.config or {}
+    bearer = _bearer(request)
     api_key = cfg.get("mcp_api_key")
-    if api_key:  # enforced when a key is configured
-        # Constant-time compare so a wrong key can't be recovered via timing (matches deps.py).
-        if not hmac.compare_digest(_bearer(request) or "", api_key):
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "invalid MCP api key")
-    elif settings.auth_required:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "set project.config.mcp_api_key to expose MCP")
+    # Authorize the caller and resolve the acting end user (identity). Two accepted credentials:
+    #   - the shared per-project mcp_api_key -> authorized, NO per-user identity (server-to-server);
+    #   - a Forge session token minted for THIS project (create_session_token) -> authorized AS the
+    #     token's end_user, so entitlement gating + {{ctx.*}} act per user. Portable "use anywhere"
+    #     identity: any MCP client just sends Authorization: Bearer <token>.
+    end_user: dict | None = None
+    if api_key and hmac.compare_digest(bearer or "", api_key):
+        pass  # shared-key mode (constant-time compare; matches deps.py)
+    else:
+        # Per-user identity credentials, in order: a project-scoped session token, a per-user
+        # Personal Access Token (forge_pat_), then an OAuth 2.1 access token. Each authorizes AS
+        # that user.
+        end_user = (
+            _session_end_user(bearer, proj)
+            or await _pat_end_user(bearer, proj)
+            or await _oauth_end_user(bearer, proj)
+        )
+        if end_user is None and (api_key or settings.auth_required or settings.mcp_oauth_enabled):
+            detail = "invalid MCP credential" if api_key else "authentication required to use this MCP server"
+            headers = None
+            if settings.mcp_oauth_enabled:
+                # RFC 9728: point the client at this resource's metadata so it can start OAuth.
+                prm = f"{settings.public_base_url.rstrip('/')}/.well-known/oauth-protected-resource/v1/mcp/{project_id}"
+                headers = {"WWW-Authenticate": f'Bearer resource_metadata="{prm}"'}
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail, headers=headers)
 
     # Rate-limit the exposed MCP surface per project (a single static key is shared by every
     # caller, so this is the real abuse ceiling). Uses the general API per-minute budget.
     if not rate_limiter.allow(f"mcp:{project_id}", rate=settings.api_rate_limit_per_minute, per=60):
         raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, "MCP rate limit exceeded")
 
+    # Ephemeral per-run context (X-Forge-Context): injected into tools as {{ctx.*}} for on-behalf-of
+    # calls (e.g. the end user's downstream session); never persisted or prompted.
+    rc = parse_run_context(request)
+
     body = await request.json()
     rid = body.get("id")
     method = body.get("method")
     params = body.get("params") or {}
-    allow = _exposed_tool_names(cfg)
     wf_tool = _workflow_tool_name(cfg)
 
     if method == "initialize":
+        name = f"forge-{proj.slug or project_id}"
+        if toolset_slug:
+            name = f"{name}-{toolset_slug}"
         return _rpc(rid, {
             "protocolVersion": "2024-11-05",
             "capabilities": {"tools": {}},
-            "serverInfo": {"name": f"forge-{proj.slug or project_id}", "version": "1.0.0"},
+            "serverInfo": {"name": name, "version": "1.0.0"},
         })
 
     if method in ("tools/list", "tools/call"):
         async with SessionLocal() as s:
-            ctx = await build_compile_context(s, tenant_id=proj.tenant_id, project_id=project_id)
+            ctx = await build_compile_context(
+                s, tenant_id=proj.tenant_id, project_id=project_id, end_user=end_user, run_context=rc,
+            )
+            sets = await ToolSetService.list(s, proj.tenant_id, project_id)
+
+        # Exposed = enabled tools of exposed sets, minus any individually excluded (unticked) tools.
+        excluded_ids = {str(x) for x in (cfg.get("mcp_excluded_tools") or [])}
+        allow = _exposed_names(ctx, sets, toolset_slug, excluded_ids)
 
         if method == "tools/list":
             tools = []
             for spec in ctx.tool_specs.values():
                 tool = spec["tool"]
-                if allow is not None and tool.name not in allow:
-                    continue  # not on the project's exposed-tools allow-list
+                if tool.name not in allow:
+                    continue  # only enabled tools of exposed tool sets are published
                 schema = {}
                 try:
                     schema = tool.args_schema.model_json_schema() if tool.args_schema else {"type": "object"}
                 except Exception:  # noqa: BLE001
                     schema = {"type": "object"}
                 tools.append({"name": tool.name, "description": tool.description or "", "inputSchema": schema})
-            if wf_tool:
-                # Expose the project's configured workflow as one MCP tool (Feature: workflow-as-MCP).
+            # The whole-workflow-as-one-tool is a project-level surface: expose it on the base
+            # endpoint only, not on a per-set (toolset) endpoint.
+            if wf_tool and not toolset_slug:
                 tools.append({
                     "name": wf_tool,
                     "description": "Run this project's configured workflow with a text message and return its reply.",
@@ -132,7 +259,7 @@ async def mcp_rpc(project_id: str, request: Request):
         name = params.get("name")
         args = params.get("arguments") or {}
         # Workflow-as-MCP: run the project's configured workflow to completion and return its answer.
-        if wf_tool and name == wf_tool:
+        if wf_tool and not toolset_slug and name == wf_tool:
             from forge.routers.project_run import _configured_workflow
             from forge.services.runs import RunService
 
@@ -147,15 +274,18 @@ async def mcp_rpc(project_id: str, request: Request):
                     run = await run_service.create_run(
                         s, tenant_id=proj.tenant_id, project_id=project_id, workflow_id=wf.id,
                         input={"messages": [{"role": "user", "content": str(message)}]}, source="mcp",
+                        end_user=end_user,
                     )
-                result = await run_service.run_to_completion(run_id=run.id, tenant_id=proj.tenant_id, project_id=project_id)
+                result = await run_service.run_to_completion(
+                    run_id=run.id, tenant_id=proj.tenant_id, project_id=project_id, run_context=rc,
+                )
                 text = result.get("answer") or ""
                 return _rpc(rid, {"content": [{"type": "text", "text": text}], "isError": result.get("status") == "error"})
             except Exception:  # noqa: BLE001
                 # Don't leak internal error/stack detail to the external MCP client; log it server-side.
                 log.exception("mcp workflow run failed (project=%s)", project_id)
                 return _rpc(rid, {"content": [{"type": "text", "text": "error: workflow run failed"}], "isError": True})
-        if allow is not None and name not in allow:
+        if name not in allow:
             return _rpc(rid, error={"code": -32602, "message": f"tool {name!r} is not exposed"})
         tool = next((sp["tool"] for sp in ctx.tool_specs.values() if sp["tool"].name == name), None)
         if tool is None:

--- a/apps/api/forge/routers/mcp_tokens.py
+++ b/apps/api/forge/routers/mcp_tokens.py
@@ -1,0 +1,60 @@
+"""Personal access tokens for a project's MCP server.
+
+A PAT is a per-user, pasteable bearer token (`forge_pat_…`) that authenticates an individual over
+`POST /v1/mcp/{project_id}` AS their end_user - the portable "use anywhere" identity for generic MCP
+clients (Claude Desktop, Cursor, VS Code). Bound to the current user and scoped to this project; it
+is deliberately NOT a general-API credential.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from forge.deps import CurrentUser, get_current_user, get_session
+from forge.models.entities import ApiKey
+from forge.schemas.dto import McpTokenCreate, McpTokenOut
+from forge.services.apikeys import ApiKeyService
+
+router = APIRouter(prefix="/v1/projects/{project_id}/mcp-tokens", tags=["mcp-tokens"])
+
+
+def _out(k: ApiKey, *, token: str | None = None) -> McpTokenOut:
+    return McpTokenOut(
+        id=k.id, name=k.name, prefix=k.prefix, project_id=k.project_id, status=k.status,
+        created_at=k.created_at, last_used_at=k.last_used_at, expires_at=k.expires_at, token=token,
+    )
+
+
+def _require_real_user(user: CurrentUser) -> None:
+    # A PAT must bind a real end user; service / api-key / dev-fallback principals have no user id.
+    if user.is_fallback or str(user.id).startswith(("apikey:", "service")):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "personal tokens require a logged-in user")
+
+
+@router.get("", response_model=list[McpTokenOut])
+async def list_mcp_tokens(project_id: str, session: AsyncSession = Depends(get_session),
+                          user: CurrentUser = Depends(get_current_user)):
+    _require_real_user(user)
+    rows = await ApiKeyService.list_personal(session, user.tenant_id, user.id)
+    # Show this project's tokens plus any tenant-wide (unscoped) personal tokens.
+    return [_out(k) for k in rows if k.project_id in (None, project_id)]
+
+
+@router.post("", response_model=McpTokenOut, status_code=201)
+async def create_mcp_token(project_id: str, body: McpTokenCreate, session: AsyncSession = Depends(get_session),
+                           user: CurrentUser = Depends(get_current_user)):
+    _require_real_user(user)
+    key, plaintext = await ApiKeyService.create_personal(
+        session, tenant_id=user.tenant_id, user_id=user.id,
+        name=body.name or "MCP token", project_id=project_id, ttl_days=body.ttl_days,
+    )
+    return _out(key, token=plaintext)
+
+
+@router.delete("/{token_id}", status_code=204)
+async def revoke_mcp_token(project_id: str, token_id: str, session: AsyncSession = Depends(get_session),
+                           user: CurrentUser = Depends(get_current_user)):
+    _require_real_user(user)
+    if not await ApiKeyService.revoke_personal(session, tenant_id=user.tenant_id, user_id=user.id, key_id=token_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "token not found")

--- a/apps/api/forge/routers/tool_sets.py
+++ b/apps/api/forge/routers/tool_sets.py
@@ -1,0 +1,86 @@
+"""Tool Set endpoints (CRUD + membership).
+
+A tool set is a describable group of tools (see forge.services.tool_sets). Sets organize the
+Tools screen, can be granted to an agent as a unit, and are the unit published over MCP.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from forge.deps import CurrentUser, current_tenant_id, get_session, require_role
+from forge.models import ToolSet
+from forge.schemas.dto import ToolSetCreate, ToolSetOut, ToolSetUpdate
+from forge.services.tool_sets import ToolSetService
+
+router = APIRouter(prefix="/v1/projects/{project_id}/tool-sets", tags=["tool-sets"])
+
+
+def _to_out(ts: ToolSet, tool_ids: list[str]) -> ToolSetOut:
+    return ToolSetOut(
+        id=ts.id, project_id=ts.project_id, name=ts.name, slug=ts.slug,
+        description=ts.description or "", icon=ts.icon, is_default=ts.is_default, exposed=ts.exposed, tool_ids=tool_ids,
+    )
+
+
+async def _load(session: AsyncSession, tenant_id: str, project_id: str, set_id: str) -> ToolSet:
+    ts = await ToolSetService.get(session, tenant_id, set_id)
+    if ts is None or ts.project_id != project_id:
+        raise HTTPException(404, "Tool set not found")
+    return ts
+
+
+@router.get("", response_model=list[ToolSetOut])
+async def list_tool_sets(project_id: str, session: AsyncSession = Depends(get_session), tenant_id: str = Depends(current_tenant_id)):
+    sets = await ToolSetService.list(session, tenant_id, project_id)
+    members = await ToolSetService.members_map(session, tenant_id, project_id)
+    return [_to_out(s, members.get(s.id, [])) for s in sets]
+
+
+@router.post("", response_model=ToolSetOut, status_code=201)
+async def create_tool_set(project_id: str, body: ToolSetCreate, session: AsyncSession = Depends(get_session),
+                          tenant_id: str = Depends(current_tenant_id), _: CurrentUser = Depends(require_role("editor"))):
+    ts = await ToolSetService.create(
+        session, tenant_id, project_id, name=body.name, description=body.description,
+        icon=body.icon, is_default=body.is_default, exposed=body.exposed, tool_ids=body.tool_ids,
+    )
+    return _to_out(ts, await ToolSetService.member_ids(session, tenant_id, ts.id))
+
+
+@router.get("/{set_id}", response_model=ToolSetOut)
+async def get_tool_set(project_id: str, set_id: str, session: AsyncSession = Depends(get_session), tenant_id: str = Depends(current_tenant_id)):
+    ts = await _load(session, tenant_id, project_id, set_id)
+    return _to_out(ts, await ToolSetService.member_ids(session, tenant_id, ts.id))
+
+
+@router.patch("/{set_id}", response_model=ToolSetOut)
+async def update_tool_set(project_id: str, set_id: str, body: ToolSetUpdate, session: AsyncSession = Depends(get_session),
+                          tenant_id: str = Depends(current_tenant_id), _: CurrentUser = Depends(require_role("editor"))):
+    ts = await _load(session, tenant_id, project_id, set_id)
+    ts = await ToolSetService.update(
+        session, ts, name=body.name, description=body.description, icon=body.icon,
+        is_default=body.is_default, exposed=body.exposed, tool_ids=body.tool_ids,
+    )
+    return _to_out(ts, await ToolSetService.member_ids(session, tenant_id, ts.id))
+
+
+@router.delete("/{set_id}", status_code=204)
+async def delete_tool_set(project_id: str, set_id: str, session: AsyncSession = Depends(get_session),
+                          tenant_id: str = Depends(current_tenant_id), _: CurrentUser = Depends(require_role("editor"))):
+    ts = await _load(session, tenant_id, project_id, set_id)
+    await ToolSetService.delete(session, ts)
+
+
+@router.post("/{set_id}/tools/{tool_id}", status_code=204)
+async def add_tool_to_set(project_id: str, set_id: str, tool_id: str, session: AsyncSession = Depends(get_session),
+                          tenant_id: str = Depends(current_tenant_id), _: CurrentUser = Depends(require_role("editor"))):
+    ts = await _load(session, tenant_id, project_id, set_id)
+    await ToolSetService.add_member(session, ts, tool_id)
+
+
+@router.delete("/{set_id}/tools/{tool_id}", status_code=204)
+async def remove_tool_from_set(project_id: str, set_id: str, tool_id: str, session: AsyncSession = Depends(get_session),
+                               tenant_id: str = Depends(current_tenant_id), _: CurrentUser = Depends(require_role("editor"))):
+    ts = await _load(session, tenant_id, project_id, set_id)
+    await ToolSetService.remove_member(session, ts, tool_id)

--- a/apps/api/forge/schemas/dto.py
+++ b/apps/api/forge/schemas/dto.py
@@ -243,6 +243,58 @@ class ToolTestIn(BaseModel):
     context: dict[str, Any] | None = None
 
 
+# --- tool sets (describable groups of tools; organize the UI + expose over MCP) ---
+class ToolSetOut(ORMModel):
+    id: str
+    project_id: str
+    name: str
+    slug: str
+    description: str = ""
+    icon: str | None = None
+    is_default: bool = False
+    exposed: bool = True  # published over MCP (the MCP surface = enabled tools of exposed sets)
+    # Member tool ids (many-to-many). Assembled by the router, not an ORM attribute.
+    tool_ids: list[str] = []
+
+
+class ToolSetCreate(BaseModel):
+    name: str
+    description: str = ""
+    icon: str | None = None
+    is_default: bool = False
+    exposed: bool = True
+    tool_ids: list[str] = []
+
+
+class ToolSetUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    icon: str | None = None
+    is_default: bool | None = None
+    exposed: bool | None = None
+    # When provided, REPLACES the set's membership with exactly these tool ids.
+    tool_ids: list[str] | None = None
+
+
+# --- MCP personal access tokens (per-user MCP auth) ---
+class McpTokenOut(ORMModel):
+    id: str
+    name: str
+    prefix: str
+    project_id: str | None = None
+    status: str
+    created_at: datetime | None = None
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None
+    # Full token plaintext - returned ONCE at creation only, never stored or echoed afterwards.
+    token: str | None = None
+
+
+class McpTokenCreate(BaseModel):
+    name: str | None = None
+    ttl_days: int | None = None
+
+
 # --- auth providers ---
 class AuthProviderOut(ORMModel):
     id: str
@@ -269,6 +321,18 @@ class AuthProviderUpdate(BaseModel):
 
 class AuthTestIn(BaseModel):
     context: dict[str, Any] | None = None
+
+
+class UserConnectionIn(BaseModel):
+    """A per-user downstream credential the app owner's connect flow stores in Forge so a tool can
+    act as that end user - without the MCP/session token being passed through. Minimally an
+    access token; refresh_token + expires_at (epoch seconds) enable Forge's automatic refresh. The
+    provider must be kind oauth2_authorization_code with per_user_context_keys: ["end_user_id"]."""
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: float | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 # --- secrets (write-only; value never returned) ---

--- a/apps/api/forge/security.py
+++ b/apps/api/forge/security.py
@@ -270,6 +270,23 @@ def create_session_token(*, tenant_id: str, project_id: str, end_user: dict, ori
     )
 
 
+def create_mcp_authorization_code(*, claims: dict, ttl_minutes: int = 5) -> str:
+    """Short-lived OAuth 2.1 authorization code (MCP auth server). Carries the bound client_id,
+    redirect_uri, PKCE challenge, requested resource, and the authenticated user - so /token can
+    verify the exchange statelessly. Never returned to the model; only to the redirect_uri."""
+    return _encode(claims, timedelta(minutes=ttl_minutes), "mcp_auth_code")
+
+
+def create_mcp_access_token(*, claims: dict, ttl_minutes: int = 60) -> str:
+    """OAuth 2.1 access token for a Forge MCP resource. `aud` is bound to the project's canonical
+    MCP URL (RFC 8707); the MCP resource server validates the audience before honoring it."""
+    return _encode(claims, timedelta(minutes=ttl_minutes), "mcp_access")
+
+
+def create_mcp_refresh_token(*, claims: dict, ttl_days: int = 30) -> str:
+    return _encode(claims, timedelta(days=ttl_days), "mcp_refresh")
+
+
 def decode_token(token: str, *, expected_type: str | None = None, check_revoked: bool = True) -> dict:
     # Accept the current signing key plus any configured previous keys (rotation overlap).
     keys = [settings.jwt_secret, *(settings.jwt_secret_previous or [])]

--- a/apps/api/forge/services/apikeys.py
+++ b/apps/api/forge/services/apikeys.py
@@ -30,6 +30,13 @@ def looks_like_api_key(token: str) -> bool:
     return token.startswith(_KEY_PREFIX)
 
 
+_PAT_PREFIX = "forge_pat_"       # per-user MCP personal access token (NOT a general-API key)
+
+
+def looks_like_pat(token: str) -> bool:
+    return token.startswith(_PAT_PREFIX)
+
+
 class ApiKeyService:
     @staticmethod
     async def create(
@@ -81,6 +88,73 @@ class ApiKeyService:
             await session.execute(select(ApiKey).where(ApiKey.key_hash == _hash(presented)))
         ).scalar_one_or_none()
         if row is None or row.status != "active":
+            return None
+        now = datetime.utcnow()
+        if row.expires_at is not None and row.expires_at < now:
+            return None
+        if row.last_used_at is None or (now - row.last_used_at).total_seconds() > _LAST_USED_THROTTLE_S:
+            row.last_used_at = now
+            try:
+                await session.commit()
+            except Exception:  # noqa: BLE001 - last_used is telemetry, never fail auth on it
+                await session.rollback()
+        return row
+
+    # --- Personal access tokens (per-user, MCP-scoped) -------------------------------------
+    @staticmethod
+    async def create_personal(
+        session, *, tenant_id: str, user_id: str, name: str,
+        project_id: str | None = None, ttl_days: int | None = None,
+    ) -> tuple[ApiKey, str]:
+        """Mint a per-user PAT (prefix forge_pat_) for MCP. Bound to `user_id`, optionally scoped to
+        one `project_id`. role is 'viewer' (least privilege - the MCP path uses the end_user identity,
+        not this role, and a PAT is never accepted as a general-API principal). Plaintext shown once."""
+        plaintext = _PAT_PREFIX + _secrets.token_urlsafe(32)
+        row = ApiKey(
+            tenant_id=tenant_id, name=name, role="viewer", user_id=user_id, project_id=project_id,
+            prefix=plaintext[:_PREFIX_STORE_LEN], key_hash=_hash(plaintext), status="active",
+            expires_at=(datetime.utcnow() + timedelta(days=ttl_days)) if ttl_days else None,
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return row, plaintext
+
+    @staticmethod
+    async def list_personal(session, tenant_id: str, user_id: str) -> list[ApiKey]:
+        rows = await session.execute(
+            select(ApiKey)
+            .where(ApiKey.tenant_id == tenant_id, ApiKey.user_id == user_id)
+            .order_by(ApiKey.created_at.desc())
+        )
+        return list(rows.scalars())
+
+    @staticmethod
+    async def revoke_personal(session, *, tenant_id: str, user_id: str, key_id: str) -> bool:
+        """Revoke a PAT, but only when it belongs to this user (can't revoke another user's token)."""
+        row = (
+            await session.execute(
+                select(ApiKey).where(
+                    ApiKey.tenant_id == tenant_id, ApiKey.user_id == user_id, ApiKey.id == key_id
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return False
+        row.status = "revoked"
+        await session.commit()
+        return True
+
+    @staticmethod
+    async def resolve_personal(session, presented: str) -> ApiKey | None:
+        """Return the active, unexpired, user-bound PAT matching the presented plaintext, or None.
+        Only the forge_pat_ prefix is accepted (a general forge_sk_ key is never a PAT)."""
+        if not looks_like_pat(presented):
+            return None
+        row = (
+            await session.execute(select(ApiKey).where(ApiKey.key_hash == _hash(presented)))
+        ).scalar_one_or_none()
+        if row is None or row.status != "active" or not row.user_id:
             return None
         now = datetime.utcnow()
         if row.expires_at is not None and row.expires_at < now:

--- a/apps/api/forge/services/auth.py
+++ b/apps/api/forge/services/auth.py
@@ -23,7 +23,10 @@ from forge.security import (
     verify_totp,
 )
 
-ROLES = ("owner", "admin", "editor", "viewer")
+# "connector" is the least-privileged role: an MCP-only user who can authenticate and manage their
+# own MCP tokens, but not view/edit project resources or settings. Mutations are blocked by
+# require_role (needs editor+); the web console additionally shows connectors only their token page.
+ROLES = ("owner", "admin", "editor", "viewer", "connector")
 _RANK = {r: i for i, r in enumerate(ROLES)}  # higher index = fewer privileges
 
 

--- a/apps/api/forge/services/auth_providers.py
+++ b/apps/api/forge/services/auth_providers.py
@@ -80,3 +80,36 @@ class AuthProviderService:
             "params": {k: _mask(v) for k, v in resolved.params.items()},
             "expires_in_seconds": None if resolved.expires_at is None else max(0, int(resolved.expires_at - __import__("time").monotonic())),
         }
+
+    # --- Per-user connected credentials -----------------------------------------------------
+    # A provider of kind `oauth2_authorization_code` with config per_user_context_keys:
+    # ["end_user_id"] keys its OAuth token bundle PER end user. The methods below store/read the
+    # bundle under the exact secret name the AuthResolver reads at run time (keyed by end_user_id),
+    # so a tool call acts as the authenticated user WITHOUT the MCP token being passed downstream
+    # (no token passthrough). The app owner's own "connect account" flow calls set_user_connection
+    # after its user authorizes - Forge only stores the resulting bundle.
+    @staticmethod
+    def _bundle_name(provider_id: str, end_user_id: str) -> str:
+        return AuthResolver.bundle_secret_name(provider_id, {"end_user_id": end_user_id}, ["end_user_id"])
+
+    @staticmethod
+    async def set_user_connection(session, tenant_id: str, project_id: str, provider: AuthProvider,
+                                  end_user_id: str, *, bundle: dict) -> None:
+        name = AuthProviderService._bundle_name(provider.id, end_user_id)
+        await SecretStore().write(session, tenant_id=tenant_id, project_id=project_id, name=name, value=bundle, kind="oauth")
+
+    @staticmethod
+    async def get_user_connection(tenant_id: str, project_id: str, provider: AuthProvider, end_user_id: str) -> dict:
+        name = AuthProviderService._bundle_name(provider.id, end_user_id)
+        try:
+            bundle = await SecretStore().read_ref(tenant_id=tenant_id, project_id=project_id, ref=f"secret://proj/{name}")
+        except Exception:  # noqa: BLE001 - a missing/undecodable secret just reads as "not connected"
+            bundle = None
+        connected = isinstance(bundle, dict) and bool(bundle.get("access_token"))
+        return {"connected": connected, "expires_at": (bundle or {}).get("expires_at") if connected else None}
+
+    @staticmethod
+    async def clear_user_connection(session, tenant_id: str, project_id: str, provider: AuthProvider, end_user_id: str) -> None:
+        # Overwrite with an empty bundle (revoked); the resolver then treats the user as not connected.
+        name = AuthProviderService._bundle_name(provider.id, end_user_id)
+        await SecretStore().write(session, tenant_id=tenant_id, project_id=project_id, name=name, value={}, kind="oauth")

--- a/apps/api/forge/services/runtime.py
+++ b/apps/api/forge/services/runtime.py
@@ -119,6 +119,12 @@ async def build_compile_context(
     ctx.tool_registry = registry
     ctx.tool_specs = specs
 
+    # Tool-set membership (set_id -> [tool_id]) so an agent node can reference a whole set via
+    # config.toolsets and resolve it to member tools at compile time. One query per run.
+    from forge.services.tool_sets import ToolSetService
+
+    ctx.toolset_members = await ToolSetService.members_map(session, tenant_id, project_id)
+
     # User-defined UI components → widget-tools (Feature 2). Each becomes a tool the agent
     # can call to render a saved html/css template client-side (the tool args are the props).
     from forge.models import Component

--- a/apps/api/forge/services/tool_sets.py
+++ b/apps/api/forge/services/tool_sets.py
@@ -1,0 +1,188 @@
+"""Tool Set CRUD + membership (many-to-many Tool <-> ToolSet).
+
+A tool set is a describable group of tools. Sets organize the Tools screen (they render as
+folders), can be granted to an agent as a unit (agent config.toolsets), and can be published
+as a GitHub-style toolset over MCP. Membership is many-to-many via ToolSetMember, so a tool
+may belong to several sets. Membership is always validated to real tools in the same project.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from forge.models import Tool, ToolSet, ToolSetMember
+
+
+def _slugify(name: str) -> str:
+    """url-safe slug from a display name (matches the simple project-slug convention but
+    tolerant of punctuation): lowercase, non-alnum runs -> '-', trimmed."""
+    s = re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
+    return s or "set"
+
+
+class ToolSetService:
+    @staticmethod
+    async def list(session: AsyncSession, tenant_id: str, project_id: str) -> list[ToolSet]:
+        rows = await session.execute(
+            select(ToolSet)
+            .where(ToolSet.tenant_id == tenant_id, ToolSet.project_id == project_id)
+            .order_by(ToolSet.name)
+        )
+        return list(rows.scalars())
+
+    @staticmethod
+    async def get(session: AsyncSession, tenant_id: str, set_id: str) -> ToolSet | None:
+        row = await session.execute(
+            select(ToolSet).where(ToolSet.tenant_id == tenant_id, ToolSet.id == set_id)
+        )
+        return row.scalar_one_or_none()
+
+    @staticmethod
+    async def members_map(session: AsyncSession, tenant_id: str, project_id: str) -> dict[str, list[str]]:
+        """{tool_set_id: [tool_id, ...]} for every set in the project, in one query."""
+        rows = await session.execute(
+            select(ToolSetMember.tool_set_id, ToolSetMember.tool_id)
+            .where(ToolSetMember.tenant_id == tenant_id, ToolSetMember.project_id == project_id)
+            .order_by(ToolSetMember.created_at)
+        )
+        out: dict[str, list[str]] = {}
+        for set_id, tool_id in rows.all():
+            out.setdefault(set_id, []).append(tool_id)
+        return out
+
+    @staticmethod
+    async def member_ids(session: AsyncSession, tenant_id: str, set_id: str) -> list[str]:
+        rows = await session.execute(
+            select(ToolSetMember.tool_id)
+            .where(ToolSetMember.tenant_id == tenant_id, ToolSetMember.tool_set_id == set_id)
+            .order_by(ToolSetMember.created_at)
+        )
+        return [r[0] for r in rows.all()]
+
+    @staticmethod
+    async def tool_ids_for_sets(session: AsyncSession, tenant_id: str, project_id: str, set_ids: list[str]) -> list[str]:
+        """Union of member tool ids across the given sets, order-stable and de-duplicated.
+        Used to resolve an agent's config.toolsets into concrete tool ids at compile time."""
+        if not set_ids:
+            return []
+        rows = await session.execute(
+            select(ToolSetMember.tool_id)
+            .where(
+                ToolSetMember.tenant_id == tenant_id,
+                ToolSetMember.project_id == project_id,
+                ToolSetMember.tool_set_id.in_(list(set_ids)),
+            )
+            .order_by(ToolSetMember.created_at)
+        )
+        seen: set[str] = set()
+        out: list[str] = []
+        for (tool_id,) in rows.all():
+            if tool_id not in seen:
+                out.append(tool_id)
+                seen.add(tool_id)
+        return out
+
+    @staticmethod
+    async def _unique_slug(session: AsyncSession, tenant_id: str, project_id: str, base: str, *, current_slug: str | None = None) -> str:
+        rows = await session.execute(
+            select(ToolSet.slug).where(ToolSet.tenant_id == tenant_id, ToolSet.project_id == project_id)
+        )
+        taken = {r[0] for r in rows.all() if r[0]}
+        taken.discard(current_slug)  # a set may keep its own slug
+        slug = base
+        i = 2
+        while slug in taken:
+            slug = f"{base}-{i}"
+            i += 1
+        return slug
+
+    @staticmethod
+    async def _valid_tool_ids(session: AsyncSession, tenant_id: str, project_id: str, tool_ids: list[str]) -> list[str]:
+        """Filter to tool ids that are real tools in this project; preserve order, de-dupe."""
+        if not tool_ids:
+            return []
+        rows = await session.execute(
+            select(Tool.id).where(
+                Tool.tenant_id == tenant_id, Tool.project_id == project_id, Tool.id.in_(list(tool_ids))
+            )
+        )
+        found = {r[0] for r in rows.all()}
+        seen: set[str] = set()
+        out: list[str] = []
+        for tid in tool_ids:
+            if tid in found and tid not in seen:
+                out.append(tid)
+                seen.add(tid)
+        return out
+
+    @staticmethod
+    async def _replace_members(session: AsyncSession, tenant_id: str, project_id: str, set_id: str, tool_ids: list[str]) -> None:
+        valid = await ToolSetService._valid_tool_ids(session, tenant_id, project_id, tool_ids)
+        await session.execute(delete(ToolSetMember).where(ToolSetMember.tool_set_id == set_id))
+        for tid in valid:
+            session.add(ToolSetMember(tenant_id=tenant_id, project_id=project_id, tool_set_id=set_id, tool_id=tid))
+
+    @staticmethod
+    async def create(session: AsyncSession, tenant_id: str, project_id: str, *, name: str, description: str = "",
+                     icon: str | None = None, is_default: bool = False, exposed: bool = True,
+                     tool_ids: list[str] | None = None) -> ToolSet:
+        slug = await ToolSetService._unique_slug(session, tenant_id, project_id, _slugify(name))
+        ts = ToolSet(
+            tenant_id=tenant_id, project_id=project_id, name=name, slug=slug,
+            description=description or "", icon=icon or None, is_default=bool(is_default), exposed=bool(exposed),
+        )
+        session.add(ts)
+        await session.flush()  # populate ts.id before inserting membership rows
+        if tool_ids:
+            await ToolSetService._replace_members(session, tenant_id, project_id, ts.id, tool_ids)
+        await session.commit()
+        await session.refresh(ts)
+        return ts
+
+    @staticmethod
+    async def update(session: AsyncSession, ts: ToolSet, *, name: str | None = None, description: str | None = None,
+                     icon: str | None = None, is_default: bool | None = None, exposed: bool | None = None,
+                     tool_ids: list[str] | None = None) -> ToolSet:
+        if name is not None and name != ts.name:
+            ts.name = name
+            ts.slug = await ToolSetService._unique_slug(session, ts.tenant_id, ts.project_id, _slugify(name), current_slug=ts.slug)
+        if description is not None:
+            ts.description = description
+        if icon is not None:
+            ts.icon = icon or None
+        if is_default is not None:
+            ts.is_default = bool(is_default)
+        if exposed is not None:
+            ts.exposed = bool(exposed)
+        if tool_ids is not None:
+            await ToolSetService._replace_members(session, ts.tenant_id, ts.project_id, ts.id, tool_ids)
+        await session.commit()
+        await session.refresh(ts)
+        return ts
+
+    @staticmethod
+    async def delete(session: AsyncSession, ts: ToolSet) -> None:
+        await session.execute(delete(ToolSetMember).where(ToolSetMember.tool_set_id == ts.id))
+        await session.delete(ts)
+        await session.commit()
+
+    @staticmethod
+    async def add_member(session: AsyncSession, ts: ToolSet, tool_id: str) -> None:
+        if not await ToolSetService._valid_tool_ids(session, ts.tenant_id, ts.project_id, [tool_id]):
+            return  # ignore unknown / cross-project tool ids
+        existing = await session.execute(
+            select(ToolSetMember.id).where(ToolSetMember.tool_set_id == ts.id, ToolSetMember.tool_id == tool_id)
+        )
+        if existing.scalar_one_or_none() is None:
+            session.add(ToolSetMember(tenant_id=ts.tenant_id, project_id=ts.project_id, tool_set_id=ts.id, tool_id=tool_id))
+            await session.commit()
+
+    @staticmethod
+    async def remove_member(session: AsyncSession, ts: ToolSet, tool_id: str) -> None:
+        await session.execute(
+            delete(ToolSetMember).where(ToolSetMember.tool_set_id == ts.id, ToolSetMember.tool_id == tool_id)
+        )
+        await session.commit()

--- a/apps/api/forge/services/tools.py
+++ b/apps/api/forge/services/tools.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from forge.auth_providers.resolver import AuthResolver
-from forge.models import Tool
+from forge.models import Tool, ToolSetMember
 from forge.secrets.store import SecretStore
 from forge.tools.graphql import execute_graphql
 from forge.tools.projection import estimate_tokens
@@ -55,7 +55,9 @@ class ToolService:
     @staticmethod
     async def delete(session: AsyncSession, tool: Tool) -> None:
         """Delete a tool. Agents/workflows reference tools by id in their config; the
-        compiler tolerates missing ids (tools_for skips them), so deletion is safe."""
+        compiler tolerates missing ids (tools_for skips them), so deletion is safe. Also
+        remove the tool from any tool sets - membership rows have no DB-level cascade."""
+        await session.execute(delete(ToolSetMember).where(ToolSetMember.tool_id == tool.id))
         await session.delete(tool)
         await session.commit()
 

--- a/apps/api/forge/tools/graphql.py
+++ b/apps/api/forge/tools/graphql.py
@@ -100,10 +100,15 @@ def build_graphql_tool(cfg: dict, ctx):
         # Same three-lane context as the REST tool (kept in sync): per-run injected context,
         # LangGraph runtime context, then the authoritative end_user identity. Reaches the auth
         # resolver (per_user_context_keys / csrf_session) for on-behalf-of GraphQL calls.
+        eu = getattr(ctx, "end_user", None)
         context = {
             **(getattr(ctx, "run_context", None) or {}),
             **(getattr(runtime, "context", None) or {}),
-            "end_user": getattr(ctx, "end_user", None),
+            "end_user": eu,
+            # Stable per-user keys (authoritative), matching the REST tool: enable {{ctx.end_user_id}}
+            # and per_user_context_keys: ["end_user_id"] for per-user connected credentials.
+            "end_user_id": eu.get("id") if isinstance(eu, dict) else None,
+            "end_user_email": eu.get("email") if isinstance(eu, dict) else None,
         }
         res = await execute_graphql(
             cfg, kwargs, tenant_id=ctx.tenant_id, project_id=ctx.project_id,

--- a/apps/api/forge/tools/rest.py
+++ b/apps/api/forge/tools/rest.py
@@ -722,10 +722,16 @@ def build_rest_tool(cfg: dict, ctx):
         #     never in the prompt, never an LLM arg.
         #   - runtime.context: LangGraph runtime context, if any.
         #   - end_user: the run's identity - authoritative, so it can't be shadowed by the above.
+        eu = getattr(ctx, "end_user", None)
         context = {
             **(getattr(ctx, "run_context", None) or {}),
             **(getattr(runtime, "context", None) or {}),
-            "end_user": getattr(ctx, "end_user", None),
+            "end_user": eu,
+            # Stable per-user keys (authoritative - added last so they override any injected value):
+            # let a tool template {{ctx.end_user_id}} and let an auth provider key PER-USER connected
+            # credentials via config per_user_context_keys: ["end_user_id"] (see AuthResolver).
+            "end_user_id": eu.get("id") if isinstance(eu, dict) else None,
+            "end_user_email": eu.get("email") if isinstance(eu, dict) else None,
         }
         sw = getattr(runtime, "stream_writer", None)
         res = await execute_rest(

--- a/apps/api/migrations/versions/0007_tool_sets.py
+++ b/apps/api/migrations/versions/0007_tool_sets.py
@@ -1,0 +1,91 @@
+"""tool sets + membership
+
+Adds first-class Tool Sets (describable groups of tools) and their many-to-many membership
+join, introduced by the tool-sets / MCP-toolsets work. `create_all` builds these in dev;
+managed Postgres needs this migration.
+
+  - tool_sets          (name, slug, description, icon, is_default; unique slug per project)
+  - tool_set_members   (tool_set_id <-> tool_id, unique per pair)
+
+Column types / nullability mirror the ORM's `create_all` output so a dev SQLite database and
+a migrated Postgres database converge. NOT NULL columns that carry an ORM-side default also
+get a `server_default` (mirrors 0004) so the tables are insertable via raw SQL.
+
+Idempotent: each table is created only when absent, so this is safe whether the DB was
+created fresh by `create_all` (tables already present) or predates the feature. Tenant-
+isolation RLS policies for these tables live in infra/postgres_rls.sql.
+
+Revision ID: 0007_tool_sets
+Revises: 0006_drop_tool_agent_version
+Create Date: 2026-07-15
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0007_tool_sets"
+down_revision = "0006_drop_tool_agent_version"
+branch_labels = None
+depends_on = None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _has_table(insp, name: str) -> bool:
+    return name in insp.get_table_names()
+
+
+def _pk_timestamp_cols() -> list[sa.Column]:
+    # Mirrors db.base.PkTimestamp: string-UUID PK + created/updated timestamps (nullable to
+    # match the 0002/0003/0004 precedent; the ORM populates them on every insert).
+    return [
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+    ]
+
+
+def upgrade() -> None:
+    insp = _inspector()
+
+    # --- tool_sets -----------------------------------------------------------------------
+    if not _has_table(insp, "tool_sets"):
+        op.create_table(
+            "tool_sets",
+            *_pk_timestamp_cols(),
+            sa.Column("tenant_id", sa.String(36), nullable=False),
+            sa.Column("project_id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(120), nullable=False),
+            sa.Column("slug", sa.String(120), nullable=False),
+            sa.Column("description", sa.Text(), server_default="", nullable=False),
+            sa.Column("icon", sa.String(60), nullable=True),
+            sa.Column("is_default", sa.Boolean(), server_default=sa.false(), nullable=False),
+            sa.UniqueConstraint("tenant_id", "project_id", "slug", name="uq_tool_set_slug"),
+        )
+        op.create_index("ix_tool_sets_tenant_id", "tool_sets", ["tenant_id"])
+        op.create_index("ix_tool_sets_project_id", "tool_sets", ["project_id"])
+        op.create_index("ix_tool_sets_slug", "tool_sets", ["slug"])
+
+    # --- tool_set_members ----------------------------------------------------------------
+    if not _has_table(insp, "tool_set_members"):
+        op.create_table(
+            "tool_set_members",
+            *_pk_timestamp_cols(),
+            sa.Column("tenant_id", sa.String(36), nullable=False),
+            sa.Column("project_id", sa.String(36), nullable=False),
+            sa.Column("tool_set_id", sa.String(36), nullable=False),
+            sa.Column("tool_id", sa.String(36), nullable=False),
+            sa.UniqueConstraint("tool_set_id", "tool_id", name="uq_tool_set_member"),
+        )
+        op.create_index("ix_tool_set_members_tenant_id", "tool_set_members", ["tenant_id"])
+        op.create_index("ix_tool_set_members_project_id", "tool_set_members", ["project_id"])
+        op.create_index("ix_tool_set_members_tool_set_id", "tool_set_members", ["tool_set_id"])
+        op.create_index("ix_tool_set_members_tool_id", "tool_set_members", ["tool_id"])
+
+
+def downgrade() -> None:
+    insp = _inspector()
+    for table in ("tool_set_members", "tool_sets"):
+        if _has_table(insp, table):
+            op.drop_table(table)

--- a/apps/api/migrations/versions/0008_apikey_user_scope.py
+++ b/apps/api/migrations/versions/0008_apikey_user_scope.py
@@ -1,0 +1,44 @@
+"""api_keys: user_id + project_id (personal access tokens for MCP)
+
+Adds two nullable columns to `api_keys` so a key can be a per-user Personal Access Token (PAT)
+scoped to a single project - used to authenticate an individual over a project's MCP server as an
+end_user. Existing (tenant, role) server-to-server keys leave both NULL and are unaffected.
+
+Idempotent: each column is added only when absent, so this is safe whether the table was created
+fresh by `create_all` (columns already present via the ORM) or predates the feature.
+
+Revision ID: 0008_apikey_user_scope
+Revises: 0007_tool_sets
+Create Date: 2026-07-15
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0008_apikey_user_scope"
+down_revision = "0007_tool_sets"
+branch_labels = None
+depends_on = None
+
+
+def _cols(insp, table: str) -> set[str]:
+    return {c["name"] for c in insp.get_columns(table)} if table in insp.get_table_names() else set()
+
+
+def upgrade() -> None:
+    insp = sa.inspect(op.get_bind())
+    existing = _cols(insp, "api_keys")
+    if "api_keys" not in insp.get_table_names():
+        return  # fresh DBs build the column from the ORM; nothing to alter
+    if "user_id" not in existing:
+        op.add_column("api_keys", sa.Column("user_id", sa.String(36), nullable=True))
+    if "project_id" not in existing:
+        op.add_column("api_keys", sa.Column("project_id", sa.String(36), nullable=True))
+
+
+def downgrade() -> None:
+    insp = sa.inspect(op.get_bind())
+    existing = _cols(insp, "api_keys")
+    if "project_id" in existing:
+        op.drop_column("api_keys", "project_id")
+    if "user_id" in existing:
+        op.drop_column("api_keys", "user_id")

--- a/apps/api/migrations/versions/0009_oauth_clients.py
+++ b/apps/api/migrations/versions/0009_oauth_clients.py
@@ -1,0 +1,41 @@
+"""oauth_clients (MCP OAuth 2.1 dynamic client registration)
+
+Adds the `oauth_clients` table: dynamically-registered OAuth 2.1 public clients (RFC 7591) for the
+MCP authorization server (a client_id + an exact-match redirect_uri allow-list). Global registry
+(no tenant_id) - the user identity is bound later at the authorize step. Only used when
+`settings.mcp_oauth_enabled` is on. `create_all` builds this in dev; managed Postgres needs this.
+
+Idempotent: created only when absent.
+
+Revision ID: 0009_oauth_clients
+Revises: 0008_apikey_user_scope
+Create Date: 2026-07-15
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0009_oauth_clients"
+down_revision = "0008_apikey_user_scope"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    insp = sa.inspect(op.get_bind())
+    if "oauth_clients" not in insp.get_table_names():
+        op.create_table(
+            "oauth_clients",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("client_id", sa.String(64), nullable=False),
+            sa.Column("client_name", sa.String(200), nullable=True),
+            sa.Column("redirect_uris", sa.JSON(), server_default=sa.text("'[]'"), nullable=False),
+        )
+        op.create_index("ix_oauth_clients_client_id", "oauth_clients", ["client_id"], unique=True)
+
+
+def downgrade() -> None:
+    insp = sa.inspect(op.get_bind())
+    if "oauth_clients" in insp.get_table_names():
+        op.drop_table("oauth_clients")

--- a/apps/api/migrations/versions/0010_toolset_exposed.py
+++ b/apps/api/migrations/versions/0010_toolset_exposed.py
@@ -1,0 +1,34 @@
+"""tool_sets.exposed (GitHub-style MCP exposure)
+
+Adds `exposed` to `tool_sets`: the MCP surface is exactly the enabled tools of exposed tool sets
+(no loose per-tool exposure). Defaults to true so existing sets keep publishing. `create_all`
+builds it on fresh dev DBs; this migration covers managed Postgres and pre-existing tables.
+
+Idempotent: added only when absent.
+
+Revision ID: 0010_toolset_exposed
+Revises: 0009_oauth_clients
+Create Date: 2026-07-15
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0010_toolset_exposed"
+down_revision = "0009_oauth_clients"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    insp = sa.inspect(op.get_bind())
+    if "tool_sets" not in insp.get_table_names():
+        return
+    cols = {c["name"] for c in insp.get_columns("tool_sets")}
+    if "exposed" not in cols:
+        op.add_column("tool_sets", sa.Column("exposed", sa.Boolean(), server_default=sa.true(), nullable=False))
+
+
+def downgrade() -> None:
+    insp = sa.inspect(op.get_bind())
+    if "tool_sets" in insp.get_table_names() and "exposed" in {c["name"] for c in insp.get_columns("tool_sets")}:
+        op.drop_column("tool_sets", "exposed")

--- a/apps/api/tests/test_connected_credentials.py
+++ b/apps/api/tests/test_connected_credentials.py
@@ -1,0 +1,63 @@
+"""Per-user connected credentials: the AuthResolver picks each end user's own stored OAuth bundle,
+so a tool acts as the authenticated user downstream without the MCP token being passed through."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from forge.auth_providers.resolver import AuthResolver
+from forge.db.base import SessionLocal
+from forge.services.auth_providers import AuthProviderService
+
+
+async def _provider(tenant: str, project: str) -> str:
+    async with SessionLocal() as s:
+        ap = await AuthProviderService.create(
+            s, tenant, project, name="portal", kind="oauth2_authorization_code",
+            config={
+                "per_user_context_keys": ["end_user_id"],
+                "token_url": "https://example.com/token",
+                "header_name": "Authorization",
+                "prefix": "Bearer ",
+            },
+        )
+        return ap.id
+
+
+async def test_per_user_connected_credentials_resolve_per_end_user():
+    tenant, project = "t_conn", "p_conn"
+    ap_id = await _provider(tenant, project)
+    async with SessionLocal() as s:
+        ap = await AuthProviderService.get(s, tenant, ap_id)
+        await AuthProviderService.set_user_connection(
+            s, tenant, project, ap, "user-A", bundle={"access_token": "tok-A", "expires_at": time.time() + 3600})
+        await AuthProviderService.set_user_connection(
+            s, tenant, project, ap, "user-B", bundle={"access_token": "tok-B", "expires_at": time.time() + 3600})
+
+    resolver = AuthResolver()
+    ra = await resolver.resolve(tenant_id=tenant, project_id=project, provider_id=ap_id, context={"end_user_id": "user-A"})
+    assert ra.headers["Authorization"] == "Bearer tok-A"
+    rb = await resolver.resolve(tenant_id=tenant, project_id=project, provider_id=ap_id, context={"end_user_id": "user-B"})
+    assert rb.headers["Authorization"] == "Bearer tok-B"
+
+    # a user who never connected their account cannot authenticate (no bundle -> "not connected")
+    with pytest.raises(KeyError):
+        await resolver.resolve(tenant_id=tenant, project_id=project, provider_id=ap_id, context={"end_user_id": "user-C"})
+
+
+async def test_connection_status_and_clear():
+    tenant, project = "t_conn2", "p_conn2"
+    ap_id = await _provider(tenant, project)
+    async with SessionLocal() as s:
+        ap = await AuthProviderService.get(s, tenant, ap_id)
+        assert (await AuthProviderService.get_user_connection(tenant, project, ap, "u1"))["connected"] is False
+        await AuthProviderService.set_user_connection(s, tenant, project, ap, "u1", bundle={"access_token": "t", "expires_at": time.time() + 3600})
+    async with SessionLocal() as s:
+        ap = await AuthProviderService.get(s, tenant, ap_id)
+        assert (await AuthProviderService.get_user_connection(tenant, project, ap, "u1"))["connected"] is True
+        await AuthProviderService.clear_user_connection(s, tenant, project, ap, "u1")
+    async with SessionLocal() as s:
+        ap = await AuthProviderService.get(s, tenant, ap_id)
+        assert (await AuthProviderService.get_user_connection(tenant, project, ap, "u1"))["connected"] is False

--- a/apps/api/tests/test_mcp_oauth.py
+++ b/apps/api/tests/test_mcp_oauth.py
@@ -1,0 +1,117 @@
+"""OAuth 2.1 for MCP: discovery, dynamic client registration, authorization-code + PKCE, single-use
+codes, audience binding, and token validation on the MCP endpoint. Gated by mcp_oauth_enabled."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import urllib.parse
+import uuid
+
+import httpx
+
+from forge.config import settings
+from forge.main import create_app
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+async def _authorize_code(c, *, email, password, client_id, redirect_uri, challenge, resource) -> str:
+    form = {
+        "email": email, "password": password, "workspace_id": "", "client_id": client_id,
+        "redirect_uri": redirect_uri, "code_challenge": challenge, "state": "s", "resource": resource, "scope": "",
+    }
+    sub = await c.post("/v1/oauth/authorize", data=form, follow_redirects=False)
+    assert sub.status_code == 302, sub.text
+    q = urllib.parse.parse_qs(urllib.parse.urlparse(sub.headers["location"]).query)
+    assert q.get("state") == ["s"]
+    return q["code"][0]
+
+
+async def test_mcp_oauth_disabled_returns_404():
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        assert (await c.get("/.well-known/oauth-authorization-server")).status_code == 404
+
+
+async def test_mcp_oauth_end_to_end(monkeypatch):
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True)
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        # a real user + a project (in the user's tenant) with one tool
+        email = f"o{uuid.uuid4().hex[:10]}@example.com"
+        reg = await c.post("/v1/auth/register", json={"email": email, "password": "supersecret1"})
+        assert reg.status_code == 201, reg.text
+        c.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        pid = (await c.post("/v1/projects", json={"name": "OAuth", "slug": "oauth-proj"})).json()["id"]
+        tid = (await c.post(f"/v1/projects/{pid}/tools", json={"name": "calc", "kind": "builtin", "config": {"builtin": "calculator", "description": "c"}})).json()["id"]
+        # publish the tool via an exposed tool set (the MCP surface = exposed sets' enabled tools)
+        await c.post(f"/v1/projects/{pid}/tool-sets", json={"name": "General", "tool_ids": [tid]})
+
+        # discovery is live when enabled
+        asm = (await c.get("/.well-known/oauth-authorization-server")).json()
+        assert asm["code_challenge_methods_supported"] == ["S256"]
+        prm = (await c.get(f"/.well-known/oauth-protected-resource/v1/mcp/{pid}")).json()
+        assert prm["resource"].endswith(f"/v1/mcp/{pid}") and prm["authorization_servers"]
+
+        # dynamic client registration (RFC 7591)
+        redirect_uri = "http://localhost/callback"
+        rc = await c.post("/v1/oauth/register", json={"redirect_uris": [redirect_uri], "client_name": "Test client"})
+        assert rc.status_code == 201, rc.text
+        client_id = rc.json()["client_id"]
+
+        # the consent form renders
+        verifier, challenge = _pkce()
+        resource = f"{settings.public_base_url.rstrip('/')}/v1/mcp/{pid}"
+        gf = await c.get("/v1/oauth/authorize", params={
+            "response_type": "code", "client_id": client_id, "redirect_uri": redirect_uri,
+            "code_challenge": challenge, "code_challenge_method": "S256", "resource": resource, "state": "s",
+        })
+        assert gf.status_code == 200 and "Authorize" in gf.text
+
+        # authorization-code exchange (PKCE verifier) -> access token
+        code = await _authorize_code(c, email=email, password="supersecret1", client_id=client_id,
+                                     redirect_uri=redirect_uri, challenge=challenge, resource=resource)
+        tok = await c.post("/v1/oauth/token", data={
+            "grant_type": "authorization_code", "code": code, "redirect_uri": redirect_uri,
+            "client_id": client_id, "code_verifier": verifier,
+        })
+        assert tok.status_code == 200, tok.text
+        access = tok.json()["access_token"]
+        assert tok.json()["token_type"] == "Bearer"
+
+        # the audience-bound token authorizes the MCP endpoint
+        body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        oauth_headers = {"Authorization": f"Bearer {access}"}
+        r = await c.post(f"/v1/mcp/{pid}", headers=oauth_headers, json=body)
+        assert r.status_code == 200 and any(t["name"] == "calc" for t in r.json()["result"]["tools"])
+
+        # no credential -> 401 with an RFC 9728 discovery pointer
+        no = await c.post(f"/v1/mcp/{pid}", json=body)
+        assert no.status_code == 401 and "resource_metadata" in no.headers.get("www-authenticate", "")
+
+        # audience binding: the token must not work on a different project
+        pid2 = (await c.post("/v1/projects", json={"name": "Other", "slug": "oauth-other"})).json()["id"]
+        assert (await c.post(f"/v1/mcp/{pid2}", headers=oauth_headers, json=body)).status_code == 401
+
+        # single-use: replaying the same authorization code is rejected
+        replay = await c.post("/v1/oauth/token", data={
+            "grant_type": "authorization_code", "code": code, "redirect_uri": redirect_uri,
+            "client_id": client_id, "code_verifier": verifier,
+        })
+        assert replay.status_code == 400
+
+        # PKCE is enforced: a fresh code with the wrong verifier fails
+        v2, ch2 = _pkce()
+        code2 = await _authorize_code(c, email=email, password="supersecret1", client_id=client_id,
+                                      redirect_uri=redirect_uri, challenge=ch2, resource=resource)
+        bad = await c.post("/v1/oauth/token", data={
+            "grant_type": "authorization_code", "code": code2, "redirect_uri": redirect_uri,
+            "client_id": client_id, "code_verifier": verifier,  # wrong verifier
+        })
+        assert bad.status_code == 400

--- a/apps/api/tests/test_mcp_server.py
+++ b/apps/api/tests/test_mcp_server.py
@@ -10,14 +10,20 @@ from forge.models import Project, Tool
 
 
 async def _seed_project_with_tool(slug="mcp-proj") -> str:
+    from forge.services.tool_sets import ToolSetService
+
     async with SessionLocal() as s:
         proj = Project(tenant_id="t_mcps", name="MCP Proj", slug=slug, config={})
         s.add(proj)
         await s.flush()
-        s.add(Tool(tenant_id="t_mcps", project_id=proj.id, name="calculator", kind="builtin",
-                   config={"builtin": "calculator", "description": "Evaluate arithmetic."}))
+        tool = Tool(tenant_id="t_mcps", project_id=proj.id, name="calculator", kind="builtin",
+                    config={"builtin": "calculator", "description": "Evaluate arithmetic."})
+        s.add(tool)
         await s.commit()
         await s.refresh(proj)
+        await s.refresh(tool)
+        # The MCP surface is the enabled tools of EXPOSED tool sets, so publish via a set.
+        await ToolSetService.create(s, "t_mcps", proj.id, name="General", tool_ids=[tool.id])
         return proj.id
 
 

--- a/apps/api/tests/test_tool_sets.py
+++ b/apps/api/tests/test_tool_sets.py
@@ -1,0 +1,333 @@
+"""Tool Sets: service CRUD + membership, agent toolset->tools resolution, and the REST API."""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+
+from forge.db.base import SessionLocal
+from forge.main import create_app
+from forge.models import Project, Tool, User
+from forge.services.runtime import build_compile_context
+from forge.services.tool_sets import ToolSetService
+from forge.services.tools import ToolService
+
+
+async def _seed(tenant: str, slug: str) -> tuple[str, str, str]:
+    async with SessionLocal() as s:
+        proj = Project(tenant_id=tenant, name="TS Proj", slug=slug, config={})
+        s.add(proj)
+        await s.flush()
+        t1 = Tool(tenant_id=tenant, project_id=proj.id, name="alpha", kind="builtin",
+                  config={"builtin": "calculator", "description": "a"})
+        t2 = Tool(tenant_id=tenant, project_id=proj.id, name="beta", kind="builtin",
+                  config={"builtin": "current_time", "description": "b"})
+        s.add_all([t1, t2])
+        await s.commit()
+        for obj in (proj, t1, t2):
+            await s.refresh(obj)
+        return proj.id, t1.id, t2.id
+
+
+async def test_tool_set_service_crud_and_membership():
+    tenant = "t_ts_svc"
+    pid, t1, t2 = await _seed(tenant, "ts-svc")
+    async with SessionLocal() as s:
+        ts = await ToolSetService.create(s, tenant, pid, name="Billing Tools", description="billing", tool_ids=[t1, t2])
+        assert ts.slug == "billing-tools"
+        assert set(await ToolSetService.member_ids(s, tenant, ts.id)) == {t1, t2}
+        assert set((await ToolSetService.members_map(s, tenant, pid))[ts.id]) == {t1, t2}
+        assert set(await ToolSetService.tool_ids_for_sets(s, tenant, pid, [ts.id])) == {t1, t2}
+
+        # unknown / cross-project ids are filtered out of membership
+        ts2 = await ToolSetService.create(s, tenant, pid, name="X", tool_ids=[t1, "does-not-exist"])
+        assert await ToolSetService.member_ids(s, tenant, ts2.id) == [t1]
+
+        # add / remove membership
+        await ToolSetService.remove_member(s, ts, t1)
+        assert await ToolSetService.member_ids(s, tenant, ts.id) == [t2]
+        await ToolSetService.add_member(s, ts, t1)
+        assert set(await ToolSetService.member_ids(s, tenant, ts.id)) == {t1, t2}
+        await ToolSetService.add_member(s, ts, t1)  # idempotent (no duplicate row)
+        assert len(await ToolSetService.member_ids(s, tenant, ts.id)) == 2
+
+        # rename regenerates a unique slug (collides with ts2's "x")
+        ts = await ToolSetService.update(s, ts, name="X")
+        assert ts.slug == "x-2"
+
+        # update can replace membership wholesale
+        ts = await ToolSetService.update(s, ts, tool_ids=[t2])
+        assert await ToolSetService.member_ids(s, tenant, ts.id) == [t2]
+
+        # delete removes the set and its membership rows
+        set_id = ts.id
+        await ToolSetService.delete(s, ts)
+        assert await ToolSetService.get(s, tenant, set_id) is None
+        assert set_id not in await ToolSetService.members_map(s, tenant, pid)
+
+
+async def test_tool_deletion_removes_membership():
+    tenant = "t_ts_del"
+    pid, t1, t2 = await _seed(tenant, "ts-del")
+    async with SessionLocal() as s:
+        ts = await ToolSetService.create(s, tenant, pid, name="S", tool_ids=[t1, t2])
+        tool = await ToolService.get(s, tenant, t1)
+        await ToolService.delete(s, tool)  # deleting a tool must drop its membership rows
+        assert await ToolSetService.member_ids(s, tenant, ts.id) == [t2]
+
+
+async def test_build_compile_context_resolves_toolset_to_member_tools():
+    tenant = "t_ts_ctx"
+    pid, t1, t2 = await _seed(tenant, "ts-ctx")
+    async with SessionLocal() as s:
+        set_id = (await ToolSetService.create(s, tenant, pid, name="Set A", tool_ids=[t1, t2])).id
+    async with SessionLocal() as s:
+        ctx = await build_compile_context(s, tenant_id=tenant, project_id=pid)
+    # membership is loaded onto the compile context
+    assert set(ctx.toolset_members.get(set_id, [])) == {t1, t2}
+    # an agent granted only the set resolves to the set's member tool ids...
+    assert set(ctx.resolve_tool_ids([], [set_id])) == {t1, t2}
+    # ...and to the materialized tools (both builtins compiled into the registry)
+    assert len(ctx.tools_for(ctx.resolve_tool_ids([], [set_id]))) == 2
+
+
+async def test_tool_sets_api_end_to_end():
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        # register a real user (mutations require a real principal, not the dev fallback)
+        reg = await c.post("/v1/auth/register", json={"email": f"u{uuid.uuid4().hex[:10]}@example.com", "password": "supersecret1"})
+        assert reg.status_code == 201, reg.text
+        c.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        # project + two tools, all via the API (one consistent tenant = the registered workspace)
+        pid = (await c.post("/v1/projects", json={"name": "API TS", "slug": "api-ts"})).json()["id"]
+
+        def _mk(name: str, builtin: str) -> dict:
+            return {"name": name, "kind": "builtin", "config": {"builtin": builtin, "description": name}}
+
+        t1 = (await c.post(f"/v1/projects/{pid}/tools", json=_mk("aa", "calculator"))).json()["id"]
+        t2 = (await c.post(f"/v1/projects/{pid}/tools", json=_mk("bb", "current_time"))).json()["id"]
+
+        # create a set with one member
+        r = await c.post(f"/v1/projects/{pid}/tool-sets", json={"name": "Group One", "description": "g1", "tool_ids": [t1]})
+        assert r.status_code == 201, r.text
+        st = r.json()
+        assert st["slug"] == "group-one" and st["tool_ids"] == [t1] and st["description"] == "g1"
+        sid = st["id"]
+
+        # list
+        r = await c.get(f"/v1/projects/{pid}/tool-sets")
+        assert r.status_code == 200 and any(x["id"] == sid for x in r.json())
+
+        # add + remove via the membership endpoints
+        assert (await c.post(f"/v1/projects/{pid}/tool-sets/{sid}/tools/{t2}")).status_code == 204
+        assert set((await c.get(f"/v1/projects/{pid}/tool-sets/{sid}")).json()["tool_ids"]) == {t1, t2}
+        assert (await c.delete(f"/v1/projects/{pid}/tool-sets/{sid}/tools/{t1}")).status_code == 204
+
+        # patch: rename + replace membership
+        r = await c.patch(f"/v1/projects/{pid}/tool-sets/{sid}", json={"name": "Renamed", "tool_ids": [t1, t2]})
+        assert r.json()["slug"] == "renamed" and set(r.json()["tool_ids"]) == {t1, t2}
+
+        # delete
+        assert (await c.delete(f"/v1/projects/{pid}/tool-sets/{sid}")).status_code == 204
+        assert (await c.get(f"/v1/projects/{pid}/tool-sets/{sid}")).status_code == 404
+
+
+async def _seed_mcp_project(tenant: str, slug: str) -> tuple[str, str, str]:
+    """Project + two builtin tools; returns (project_id, calc_tool_id, clock_tool_id)."""
+    async with SessionLocal() as s:
+        proj = Project(tenant_id=tenant, name="MCP TS", slug=slug, config={})
+        s.add(proj)
+        await s.flush()
+        ta = Tool(tenant_id=tenant, project_id=proj.id, name="calc", kind="builtin",
+                  config={"builtin": "calculator", "description": "c"})
+        tb = Tool(tenant_id=tenant, project_id=proj.id, name="clock", kind="builtin",
+                  config={"builtin": "current_time", "description": "t"})
+        s.add_all([ta, tb])
+        await s.commit()
+        for obj in (proj, ta, tb):
+            await s.refresh(obj)
+        return proj.id, ta.id, tb.id
+
+
+async def _list_names(c: httpx.AsyncClient, path: str) -> set[str]:
+    r = await c.post(path, json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    return {t["name"] for t in r.json()["result"]["tools"]}
+
+
+async def test_mcp_toolset_scoped_exposure():
+    tenant = "t_mcp_ts"
+    pid, a_id, b_id = await _seed_mcp_project(tenant, "mcp-ts")
+    async with SessionLocal() as s:
+        await ToolSetService.create(s, tenant, pid, name="Set A", tool_ids=[a_id])
+        set_b = await ToolSetService.create(s, tenant, pid, name="Set B", tool_ids=[b_id])
+        b_slug, b_set_id = set_b.slug, set_b.id
+
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        # base endpoint = flat union of every EXPOSED set's enabled tools
+        assert await _list_names(c, f"/v1/mcp/{pid}") == {"calc", "clock"}
+        # per-set endpoint = just that set's flat list
+        assert await _list_names(c, f"/v1/mcp/{pid}/toolset/{b_slug}") == {"clock"}
+        assert await _list_names(c, f"/v1/mcp/{pid}/toolset/nope") == set()  # unknown slug => empty
+        r = await c.post(f"/v1/mcp/{pid}/toolset/{b_slug}", json={"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                                                                  "params": {"name": "clock", "arguments": {}}})
+        assert r.json()["result"]["isError"] is False
+
+        # un-expose Set B -> it drops off both the base surface and its own endpoint
+        async with SessionLocal() as s:
+            await ToolSetService.update(s, await ToolSetService.get(s, tenant, b_set_id), exposed=False)
+        assert await _list_names(c, f"/v1/mcp/{pid}") == {"calc"}
+        assert await _list_names(c, f"/v1/mcp/{pid}/toolset/{b_slug}") == set()
+        r = await c.post(f"/v1/mcp/{pid}", json={"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                                                 "params": {"name": "clock", "arguments": {}}})
+        assert "not exposed" in r.json()["error"]["message"]
+
+
+async def test_mcp_tool_level_exclusion():
+    """Everything in an exposed set is published by default; an operator can untick individual
+    tools via project.config.mcp_excluded_tools."""
+    tenant = "t_mcp_excl"
+    pid, a_id, b_id = await _seed_mcp_project(tenant, "mcp-excl")
+    async with SessionLocal() as s:
+        await ToolSetService.create(s, tenant, pid, name="Set", tool_ids=[a_id, b_id])
+        proj = await s.get(Project, pid)
+        proj.config = {"mcp_excluded_tools": [b_id]}  # untick 'clock'
+        await s.commit()
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        assert await _list_names(c, f"/v1/mcp/{pid}") == {"calc"}
+
+
+async def test_mcp_no_toolsets_exposes_nothing():
+    tenant = "t_mcp_none"
+    pid, a_id, _b = await _seed_mcp_project(tenant, "mcp-none")
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        # No tool sets => nothing published (there are no loose / "direct" tools).
+        assert await _list_names(c, f"/v1/mcp/{pid}") == set()
+        # once a tool is placed in an exposed set, it appears
+        async with SessionLocal() as s:
+            await ToolSetService.create(s, tenant, pid, name="General", tool_ids=[a_id])
+        assert await _list_names(c, f"/v1/mcp/{pid}") == {"calc"}
+
+
+async def test_mcp_session_token_authorizes_as_end_user():
+    """A project-scoped Forge session token authenticates an MCP caller AS its end_user
+    (the portable per-user identity channel), alongside the shared project key."""
+    from forge.security import create_session_token
+
+    tenant = "t_mcp_sess"
+    async with SessionLocal() as s:
+        proj = Project(tenant_id=tenant, name="Sess", slug="mcp-sess", config={"mcp_api_key": "shared-key"})
+        s.add(proj)
+        await s.flush()
+        s.add(Tool(tenant_id=tenant, project_id=proj.id, name="calc", kind="builtin",
+                   config={"builtin": "calculator", "description": "c"}))
+        await s.commit()
+        await s.refresh(proj)
+        pid = proj.id
+
+    good = create_session_token(tenant_id=tenant, project_id=pid, end_user={"id": "u1", "entitlements": ["billing"]})
+    wrong_project = create_session_token(tenant_id=tenant, project_id="another", end_user={"id": "u2"})
+    body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        # shared key -> authorized (no per-user identity)
+        assert (await c.post(f"/v1/mcp/{pid}", headers={"Authorization": "Bearer shared-key"}, json=body)).status_code == 200
+        # project-scoped session token -> authorized as that end user
+        assert (await c.post(f"/v1/mcp/{pid}", headers={"Authorization": f"Bearer {good}"}, json=body)).status_code == 200
+        # session token scoped to a different project -> rejected
+        assert (await c.post(f"/v1/mcp/{pid}", headers={"Authorization": f"Bearer {wrong_project}"}, json=body)).status_code == 401
+        # no credential -> rejected (a key is configured)
+        assert (await c.post(f"/v1/mcp/{pid}", json=body)).status_code == 401
+
+
+async def test_mcp_personal_access_token_authorizes_as_user():
+    """A per-user Personal Access Token (forge_pat_) authenticates an MCP client as that user."""
+    from forge.services.apikeys import ApiKeyService
+
+    tenant = "t_mcp_pat"
+    async with SessionLocal() as s:
+        proj = Project(tenant_id=tenant, name="PAT", slug="mcp-pat", config={"mcp_api_key": "shared-key"})
+        s.add(proj)
+        await s.flush()
+        s.add(Tool(tenant_id=tenant, project_id=proj.id, name="calc", kind="builtin",
+                   config={"builtin": "calculator", "description": "c"}))
+        user = User(tenant_id=tenant, email="pat-user@example.com", role="editor", status="active")
+        s.add(user)
+        await s.commit()
+        await s.refresh(proj)
+        await s.refresh(user)
+        pid = proj.id
+        _k1, pat = await ApiKeyService.create_personal(s, tenant_id=tenant, user_id=user.id, name="t", project_id=pid)
+        key_id = _k1.id
+        _k2, pat_other = await ApiKeyService.create_personal(s, tenant_id=tenant, user_id=user.id, name="t2", project_id="another-project")
+
+    body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        # a project-scoped PAT authorizes
+        assert (await c.post(f"/v1/mcp/{pid}", headers={"Authorization": f"Bearer {pat}"}, json=body)).status_code == 200
+        # a PAT scoped to a different project is rejected here
+        assert (await c.post(f"/v1/mcp/{pid}", headers={"Authorization": f"Bearer {pat_other}"}, json=body)).status_code == 401
+        # once revoked, the PAT no longer authorizes
+        async with SessionLocal() as s:
+            await ApiKeyService.revoke_personal(s, tenant_id=tenant, user_id=user.id, key_id=key_id)
+        assert (await c.post(f"/v1/mcp/{pid}", headers={"Authorization": f"Bearer {pat}"}, json=body)).status_code == 401
+
+
+async def test_mcp_token_api_crud():
+    """The user-facing PAT endpoints mint / list / revoke tokens, and a minted token works on MCP."""
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        reg = await c.post("/v1/auth/register", json={"email": f"u{uuid.uuid4().hex[:10]}@example.com", "password": "supersecret1"})
+        assert reg.status_code == 201, reg.text
+        c.headers["Authorization"] = f"Bearer {reg.json()['access_token']}"
+        pid = (await c.post("/v1/projects", json={"name": "PAT API", "slug": "pat-api"})).json()["id"]
+        # lock the MCP surface behind a key so credential checks are meaningful
+        await c.patch(f"/v1/projects/{pid}", json={"config": {"mcp_api_key": "k"}})
+
+        r = await c.post(f"/v1/projects/{pid}/mcp-tokens", json={"name": "my token"})
+        assert r.status_code == 201, r.text
+        tok = r.json()
+        assert tok["token"].startswith("forge_pat_") and tok["status"] == "active"
+
+        body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        # the freshly minted PAT authenticates against the MCP endpoint (auth is enforced by the key)
+        assert (await c.post(f"/v1/mcp/{pid}", json=body)).status_code == 401
+        pat_headers = {"Authorization": f"Bearer {tok['token']}"}
+        assert (await c.post(f"/v1/mcp/{pid}", headers=pat_headers, json=body)).status_code == 200
+
+        # listed without the plaintext, then revoked
+        lst = (await c.get(f"/v1/projects/{pid}/mcp-tokens")).json()
+        assert any(t["id"] == tok["id"] and t.get("token") is None for t in lst)
+        assert (await c.delete(f"/v1/projects/{pid}/mcp-tokens/{tok['id']}")).status_code == 204
+        assert (await c.post(f"/v1/mcp/{pid}", headers=pat_headers, json=body)).status_code == 401
+
+
+async def test_connector_role_is_mcp_only():
+    """A 'connector' user can manage their own MCP tokens but cannot mutate project resources."""
+    from forge.security import create_access_token
+
+    tenant = "t_conn_role"
+    async with SessionLocal() as s:
+        u = User(tenant_id=tenant, email="connector@example.com", role="connector", status="active")
+        proj = Project(tenant_id=tenant, name="Conn", slug="conn-p", config={})
+        s.add_all([u, proj])
+        await s.commit()
+        await s.refresh(u)
+        await s.refresh(proj)
+        uid, pid = u.id, proj.id
+
+    token = create_access_token(user_id=uid, tenant_id=tenant, role="connector")
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        c.headers["Authorization"] = f"Bearer {token}"
+        # cannot create/mutate project resources (needs editor+)
+        assert (await c.post("/v1/projects", json={"name": "X", "slug": "x-conn"})).status_code == 403
+        assert (await c.post(f"/v1/projects/{pid}/tool-sets", json={"name": "S"})).status_code == 403
+        # but can mint their own MCP personal access token
+        r = await c.post(f"/v1/projects/{pid}/mcp-tokens", json={"name": "my token"})
+        assert r.status_code == 201, r.text
+        assert r.json()["token"].startswith("forge_pat_")

--- a/apps/web/components/canvas/AgentConfig.tsx
+++ b/apps/web/components/canvas/AgentConfig.tsx
@@ -5,12 +5,12 @@ import { Icon } from "../icons";
 import { Field, Modal, Segmented, Tile, Toggle } from "../primitives";
 import { FieldsForm, MW_FIELDS, MultiSelectChips } from "./ConfigForm";
 import { MODELS, MIDDLEWARE_CATALOG, MW_META } from "@/lib/data";
-import type { Agent, ComponentT, McpClientT, Tool } from "@/lib/api";
+import type { Agent, ComponentT, McpClientT, Tool, ToolSet } from "@/lib/api";
 
 type Cfg = Record<string, any>;
 type MW = { type: string; enabled?: boolean; config?: Record<string, any> };
 
-export function AgentConfig({ config, onChange, tools = [], agents = [], folders = [], kinds = [], mcpServers = [], components = [] }: { config: Cfg; onChange: (c: Cfg) => void; tools?: Tool[]; agents?: Agent[]; folders?: string[]; kinds?: string[]; mcpServers?: McpClientT[]; components?: ComponentT[] }) {
+export function AgentConfig({ config, onChange, tools = [], toolSets = [], agents = [], folders = [], kinds = [], mcpServers = [], components = [] }: { config: Cfg; onChange: (c: Cfg) => void; tools?: Tool[]; toolSets?: ToolSet[]; agents?: Agent[]; folders?: string[]; kinds?: string[]; mcpServers?: McpClientT[]; components?: ComponentT[] }) {
   const set = (patch: Cfg) => onChange({ ...config, ...patch });
   const flavor = config.flavor || "agent";
   const selectedTools: string[] = config.tools || [];
@@ -19,6 +19,21 @@ export function AgentConfig({ config, onChange, tools = [], agents = [], folders
 
   const toggleTool = (id: string) =>
     set({ tools: selectedTools.includes(id) ? selectedTools.filter((t) => t !== id) : [...selectedTools, id] });
+  const selectedToolSets: string[] = config.toolsets || [];
+  const toggleToolSet = (id: string) =>
+    set({ toolsets: selectedToolSets.includes(id) ? selectedToolSets.filter((s) => s !== id) : [...selectedToolSets, id] });
+  // Tools are picked BY tool set (accordion), not from a flat list.
+  const [openSets, setOpenSets] = useState<Set<string>>(new Set());
+  const toggleOpen = (id: string) =>
+    setOpenSets((prev) => { const n = new Set(prev); if (n.has(id)) n.delete(id); else n.add(id); return n; });
+  const toolById = new Map(tools.map((t) => [t.id, t]));
+  const groupedIds = new Set(toolSets.flatMap((s) => s.tool_ids));
+  const ungrouped = tools.filter((t) => !groupedIds.has(t.id));
+  // Effective count: individually-picked tools ∪ every tool of a whole-set grant.
+  const grantedCount = new Set([
+    ...selectedTools,
+    ...toolSets.filter((s) => selectedToolSets.includes(s.id)).flatMap((s) => s.tool_ids),
+  ]).size;
   const toggleComponent = (id: string) =>
     set({ components: selectedComponents.includes(id) ? selectedComponents.filter((c) => c !== id) : [...selectedComponents, id] });
 
@@ -96,18 +111,65 @@ export function AgentConfig({ config, onChange, tools = [], agents = [], folders
         <textarea className="textarea" rows={4} value={config.system_prompt || ""} placeholder="You are a helpful support agent…" onChange={(e) => set({ system_prompt: e.target.value })} />
       </Section>
 
-      <CollapsibleSection label="Tools" badge={selectedTools.length ? `${selectedTools.length} selected` : undefined}
-        hint={tools.length ? undefined : "No tools in this project yet - add them on the Tools screen."}>
-        <div className="row gap2 wrap">
-          {tools.map((t) => {
-            const on = selectedTools.includes(t.id);
+      <CollapsibleSection label="Tools" badge={grantedCount ? `${grantedCount} selected` : undefined}
+        hint="Tools are organized by tool set — open a set and tick the tools this agent should use, or grant the whole set. Manage sets on the Tools screen.">
+        <div className="col gap1">
+          {toolSets.map((s) => {
+            const open = openSets.has(s.id);
+            const whole = selectedToolSets.includes(s.id);
+            const members = s.tool_ids.map((id) => toolById.get(id)).filter(Boolean) as Tool[];
+            const sel = whole ? members.length : members.filter((t) => selectedTools.includes(t.id)).length;
             return (
-              <button key={t.id} className="chip" onClick={() => toggleTool(t.id)}
-                style={{ cursor: "pointer", borderColor: on ? "var(--accent)" : "var(--line)", color: on ? "var(--accent)" : "var(--fg-1)", background: on ? "var(--accent-glow)" : "var(--bg-3)" }}>
-                {on && <Icon name="check" size={12} />}<span className="mono-sm">{t.name}</span>
-              </button>
+              <div key={s.id} className="card" style={{ padding: 0, overflow: "hidden" }}>
+                <div className="row spread" style={{ padding: "8px 10px", cursor: "pointer" }} onClick={() => toggleOpen(s.id)}>
+                  <div className="row gap2" style={{ alignItems: "center", minWidth: 0 }}>
+                    <Icon name={open ? "chevdown" : "chevright"} size={14} style={{ color: "var(--fg-2)", flex: "none" }} />
+                    <span className="mono-sm truncate">{s.name}</span>
+                    <span className="t-caption fg-2">{sel}/{members.length}</span>
+                  </div>
+                  <label className="row gap1" style={{ alignItems: "center", cursor: "pointer", flex: "none" }} onClick={(e) => e.stopPropagation()} title="Grant the whole set (auto-includes tools added to it later)">
+                    <input type="checkbox" checked={whole} onChange={() => toggleToolSet(s.id)} />
+                    <span className="t-caption fg-2">Whole set</span>
+                  </label>
+                </div>
+                {open && (
+                  <div className="col gap1" style={{ padding: "6px 12px 10px 30px", borderTop: "1px solid var(--line)" }}>
+                    {members.length === 0 && <div className="t-caption fg-2">No tools in this set yet.</div>}
+                    {members.map((t) => (
+                      <label key={t.id} className="row gap2" style={{ alignItems: "center", cursor: whole ? "default" : "pointer", opacity: whole ? 0.55 : 1 }}>
+                        <input type="checkbox" disabled={whole} checked={whole || selectedTools.includes(t.id)} onChange={() => toggleTool(t.id)} />
+                        <span className="mono-sm">{t.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
             );
           })}
+          {ungrouped.length > 0 && (
+            <div className="card" style={{ padding: 0, overflow: "hidden" }}>
+              <div className="row spread" style={{ padding: "8px 10px", cursor: "pointer" }} onClick={() => toggleOpen("__ungrouped")}>
+                <div className="row gap2" style={{ alignItems: "center" }}>
+                  <Icon name={openSets.has("__ungrouped") ? "chevdown" : "chevright"} size={14} style={{ color: "var(--fg-2)", flex: "none" }} />
+                  <span className="mono-sm fg-2">Ungrouped</span>
+                  <span className="t-caption fg-2">{ungrouped.filter((t) => selectedTools.includes(t.id)).length}/{ungrouped.length}</span>
+                </div>
+              </div>
+              {openSets.has("__ungrouped") && (
+                <div className="col gap1" style={{ padding: "6px 12px 10px 30px", borderTop: "1px solid var(--line)" }}>
+                  {ungrouped.map((t) => (
+                    <label key={t.id} className="row gap2" style={{ alignItems: "center", cursor: "pointer" }}>
+                      <input type="checkbox" checked={selectedTools.includes(t.id)} onChange={() => toggleTool(t.id)} />
+                      <span className="mono-sm">{t.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          {toolSets.length === 0 && ungrouped.length === 0 && (
+            <div className="t-caption fg-2">No tools yet — create some on the Tools screen.</div>
+          )}
         </div>
       </CollapsibleSection>
 

--- a/apps/web/components/login.tsx
+++ b/apps/web/components/login.tsx
@@ -6,7 +6,8 @@ backend returns the seeded owner, so the gate passes straight through and the co
 works as before. When FORGE_AUTH_REQUIRED=true, an unauthenticated /me returns 401 and
 the gate shows this screen. */
 import { ReactNode, useCallback, useEffect, useState } from "react";
-import { api, setTokens, UNAUTHORIZED_EVENT } from "@/lib/api";
+import { api, clearTokens, setTokens, UNAUTHORIZED_EVENT } from "@/lib/api";
+import type { MeResult, Project } from "@/lib/api";
 
 function AcceptInviteScreen({ token, onAuthed, onCancel }: { token: string; onAuthed: () => void; onCancel: () => void }) {
   const [info, setInfo] = useState<{ email: string; role: string } | null>(null);
@@ -129,6 +130,7 @@ function LoginScreen({ onAuthed }: { onAuthed: () => void }) {
 
 export function AuthGate({ children }: { children: ReactNode }) {
   const [state, setState] = useState<"loading" | "authed" | "login">("loading");
+  const [me, setMe] = useState<MeResult | null>(null);
   const [invite, setInvite] = useState<string | null>(null);
   // An invite link (?invite=<token>) takes over the gate so a new teammate can set their
   // password even if there's a stale session in this browser.
@@ -143,7 +145,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
   }, []);
   const check = useCallback(() => {
     api.me()
-      .then(() => setState("authed"))
+      .then((m) => { setMe(m); setState("authed"); })
       .catch((e: any) => {
         // Fail OPEN: only an explicit 401 means auth is enforced and we must log in.
         // A 404/network error (e.g. an older backend without /auth/me, or auth disabled)
@@ -160,9 +162,58 @@ export function AuthGate({ children }: { children: ReactNode }) {
   }, []);
 
   if (invite)
-    return <AcceptInviteScreen token={invite} onAuthed={() => { clearInviteParam(); setState("authed"); }} onCancel={() => { clearInviteParam(); setState("login"); }} />;
+    return <AcceptInviteScreen token={invite} onAuthed={() => { clearInviteParam(); check(); }} onCancel={() => { clearInviteParam(); setState("login"); }} />;
   if (state === "loading")
     return <div style={{ display: "flex", height: "100vh", alignItems: "center", justifyContent: "center" }} className="fg-2">Loading…</div>;
-  if (state === "login") return <LoginScreen onAuthed={() => setState("authed")} />;
+  if (state === "login") return <LoginScreen onAuthed={() => check()} />;
+  // MCP-only users (connector role) get just their token page, not the full console.
+  if (me?.role === "connector") return <ConnectorHome me={me} />;
   return <>{children}</>;
+}
+
+
+/* Minimal console for an MCP-only (connector) user: pick a project, generate a personal access
+   token, and copy the endpoint - no projects/tools/settings management. */
+function ConnectorHome({ me }: { me: MeResult }) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [tokens, setTokens] = useState<Record<string, string>>({});
+  useEffect(() => { api.listProjects().then(setProjects).catch(() => {}); }, []);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const box: React.CSSProperties = { background: "var(--bg-2)", padding: 8, borderRadius: 6, overflowX: "auto", margin: "4px 0" };
+
+  async function gen(pid: string) {
+    const t = await api.createMcpToken(pid, {});
+    setTokens((prev) => ({ ...prev, [pid]: t.token || "" }));
+  }
+
+  return (
+    <div style={{ maxWidth: 640, margin: "48px auto", padding: "0 20px", fontFamily: "var(--font-ui)" }}>
+      <div className="row spread" style={{ marginBottom: 14, alignItems: "center" }}>
+        <div className="t-display" style={{ fontSize: 20 }}>Your MCP access</div>
+        <button className="btn btn-secondary btn-sm" onClick={() => { clearTokens(); window.location.reload(); }}>Sign out</button>
+      </div>
+      <div className="fg-1" style={{ marginBottom: 20 }}>
+        Signed in as <b>{me.email}</b>. Generate a personal token for a project and paste it into your MCP
+        client (Claude, Cursor, …) as <span className="mono-sm">Authorization: Bearer &lt;token&gt;</span>.
+      </div>
+      {projects.length === 0 && <div className="fg-2 t-caption">No projects available yet.</div>}
+      <div className="col gap3">
+        {projects.map((p) => (
+          <div key={p.id} className="card" style={{ padding: 16 }}>
+            <div className="t-h3" style={{ marginBottom: 6 }}>{p.name}</div>
+            <div className="t-caption fg-2">MCP endpoint</div>
+            <pre className="mono-sm" style={box}>{`${origin}/api/forge/v1/mcp/${p.id}`}</pre>
+            {tokens[p.id] ? (
+              <>
+                <div className="t-caption fg-2" style={{ marginTop: 6 }}>Access token — copy now, shown once:</div>
+                <pre className="mono-sm" style={box}>{tokens[p.id]}</pre>
+              </>
+            ) : (
+              <button className="btn btn-primary btn-sm" style={{ marginTop: 8 }} onClick={() => gen(p.id)}>Generate access token</button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/apps/web/components/screens/agents.tsx
+++ b/apps/web/components/screens/agents.tsx
@@ -5,7 +5,7 @@ import { Icon } from "../icons";
 import { StatusPill, Tile } from "../primitives";
 import { AgentConfig } from "../canvas/AgentConfig";
 import { VersionHistory } from "../version-history";
-import { api, Agent, ComponentT, McpClientT, Tool } from "@/lib/api";
+import { api, Agent, ComponentT, McpClientT, Tool, ToolSet } from "@/lib/api";
 
 const NEW_AGENT_CONFIG = { flavor: "agent", model: "openai:gpt-4o-mini", system_prompt: "", tools: [], components: [], middleware: [] };
 
@@ -94,6 +94,7 @@ export function AgentConfigScreen({ project, agentId, onBack }: { project: any; 
   const [config, setConfig] = useState<Record<string, any>>(NEW_AGENT_CONFIG);
   const [name, setName] = useState("");
   const [tools, setTools] = useState<Tool[]>([]);
+  const [toolSets, setToolSets] = useState<ToolSet[]>([]);
   const [mcpServers, setMcpServers] = useState<McpClientT[]>([]);
   const [components, setComponents] = useState<ComponentT[]>([]);
   const [folders, setFolders] = useState<string[]>([]);
@@ -103,6 +104,7 @@ export function AgentConfigScreen({ project, agentId, onBack }: { project: any; 
 
   useEffect(() => {
     if (project?.id) api.listTools(project.id).then(setTools).catch(() => {});
+    if (project?.id) api.listToolSets(project.id).then(setToolSets).catch(() => {});
     if (project?.id) api.listMcpClients(project.id).then(setMcpServers).catch(() => {});
     if (project?.id) api.listComponents(project.id).then(setComponents).catch(() => {});
     if (project?.id) api.listFolders(project.id).then(setFolders).catch(() => {});
@@ -141,7 +143,7 @@ export function AgentConfigScreen({ project, agentId, onBack }: { project: any; 
       <div className="row" style={{ flex: 1, minHeight: 0, alignItems: "stretch" }}>
         <div className="scroll-y grow" style={{ padding: 24 }}>
           <div style={{ maxWidth: 960, margin: "0 auto" }}>
-            <AgentConfig config={config} onChange={setConfig} tools={tools} mcpServers={mcpServers} components={components} folders={folders} kinds={kinds} />
+            <AgentConfig config={config} onChange={setConfig} tools={tools} toolSets={toolSets} mcpServers={mcpServers} components={components} folders={folders} kinds={kinds} />
           </div>
         </div>
         <div className="scroll-y" style={{ width: 300, flex: "none", borderLeft: "1px solid var(--line)", background: "var(--bg-1)", padding: 16 }}>

--- a/apps/web/components/screens/deploy.tsx
+++ b/apps/web/components/screens/deploy.tsx
@@ -3,8 +3,8 @@
    (Consuming external MCP servers lives in the BUILD → External MCP tab.) */
 import { ReactNode, useEffect, useState } from "react";
 import { Icon } from "../icons";
-import { CodeBlock, Field } from "../primitives";
-import { api } from "@/lib/api";
+import { CodeBlock, Field, Segmented } from "../primitives";
+import { api, type McpToken, type ToolSet } from "@/lib/api";
 import { EmbedPanel } from "./embed";
 
 /* Collapsible detail section - keeps the deep integration reference tucked away so the
@@ -44,9 +44,9 @@ function FrameRow({ event, children }: { event: string; children: ReactNode }) {
 /* Left secondary-nav sections (mirrors the Settings screen layout) so the Connect screen
    is navigable instead of one long scroll. */
 type ConnSection = "run" | "reference" | "mcp" | "embed";
-const CONN_SECTIONS: { id: ConnSection; label: string; icon: string; sub: string }[] = [
+const CONN_SECTIONS: { id: ConnSection; label: string; icon: string; sub: string; child?: boolean }[] = [
   { id: "run", label: "Run API", icon: "bolt", sub: "Call this project's workflow from your backend over one endpoint." },
-  { id: "reference", label: "Integration reference", icon: "traces", sub: "The wire format for streaming and non-streaming responses." },
+  { id: "reference", label: "Integration reference", icon: "traces", sub: "The wire format for streaming and non-streaming responses.", child: true },
   { id: "mcp", label: "MCP server", icon: "connect", sub: "Expose this project's tools to Claude Desktop, Cursor, or VS Code." },
   { id: "embed", label: "Embed", icon: "grid", sub: "Drop this project's chatbot into any website as a widget." },
 ];
@@ -55,8 +55,15 @@ const CONN_SECTIONS: { id: ConnSection; label: string; icon: string; sub: string
 export function ConnectScreen({ project }: { project: any }) {
   const [section, setSection] = useState<ConnSection>("run");
   const [tools, setTools] = useState<any[]>([]);
+  const [toolSets, setToolSets] = useState<ToolSet[]>([]);
+  const [tsSave, setTsSave] = useState<"idle" | "saving" | "saved">("idle");
+  const [excluded, setExcluded] = useState<string[]>([]);
+  const [openSets, setOpenSets] = useState<Set<string>>(new Set());
+  const [mcpTokens, setMcpTokens] = useState<McpToken[]>([]);
+  const [newToken, setNewToken] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [save, setSave] = useState<"idle" | "saving" | "saved">("idle");
+  const [credTab, setCredTab] = useState<"key" | "pat">("key"); // which credential to paste - it's either/or
   // Run-API panel: pick the workflow this project's API runs (a saved setting) + the
   // backend-facing base URL, then show the one ready-to-copy endpoint.
   const [workflows, setWorkflows] = useState<any[]>([]);
@@ -65,11 +72,17 @@ export function ConnectScreen({ project }: { project: any }) {
   const [apiBase, setApiBase] = useState(
     (process.env.NEXT_PUBLIC_FORGE_API_URL || "http://localhost:8000").replace(/\/$/, ""),
   );
-  useEffect(() => { if (project?.id) api.listTools(project.id).then(setTools).catch(() => {}); }, [project?.id]);
+  useEffect(() => {
+    if (!project?.id) return;
+    api.listTools(project.id).then(setTools).catch(() => {});
+    api.listToolSets(project.id).then(setToolSets).catch(() => {});
+    api.listMcpTokens(project.id).then(setMcpTokens).catch(() => {});
+  }, [project?.id]);
   useEffect(() => {
     if (!project?.id) return;
     Promise.all([api.getProject(project.id), api.listWorkflows(project.id)]).then(([p, ws]) => {
       setApiKey((p.config as any)?.mcp_api_key || "");
+      setExcluded(((p.config as any)?.mcp_excluded_tools as string[]) || []);
       setWorkflows(ws);
       // Default the picker to the saved API workflow; else the active one, else the first.
       const saved = (p.config as any)?.api_workflow_id;
@@ -80,7 +93,12 @@ export function ConnectScreen({ project }: { project: any }) {
 
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const url = `${origin}/api/forge/v1/mcp/${project?.id || "<project>"}`;
-  const claudeConfig = JSON.stringify({ mcpServers: { [project?.slug || "forge"]: { url, headers: { Authorization: `Bearer ${apiKey || "<set-an-api-key>"}` } } } }, null, 2);
+  const claudeConfig = JSON.stringify({ mcpServers: { [project?.slug || "forge"]: { url, headers: { Authorization: "Bearer <PAT or API key>" } } } }, null, 2);
+  // The MCP surface = enabled tools of EXPOSED sets, minus individually excluded ones (mirrors
+  // the server; see mcp_server.py._exposed_names).
+  const toolById = new Map(tools.map((t) => [t.id, t]));
+  const exposedToolIds = new Set(toolSets.filter((s) => s.exposed).flatMap((s) => s.tool_ids).filter((id) => !excluded.includes(id)));
+  const exposedTools = tools.filter((t) => t.enabled && exposedToolIds.has(t.id));
 
   // Run API (server-to-server): a backend hits the Forge API DIRECTLY, not the web proxy.
   // ONE endpoint per project - it runs the workflow chosen above; `stream` is the only
@@ -156,6 +174,38 @@ export function ConnectScreen({ project }: { project: any }) {
     saveKey("fmcp_" + Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(""));
   };
 
+  // Publish a subset of tool sets on the base MCP endpoint (project.config.mcp_published_toolsets,
+  // a list of set slugs). Empty => the base endpoint exposes every enabled tool (prior behavior).
+  async function toggleExposed(ts: ToolSet) {
+    setTsSave("saving");
+    const updated = await api.updateToolSet(project.id, ts.id, { exposed: !ts.exposed });
+    setToolSets((prev) => prev.map((x) => (x.id === ts.id ? updated : x)));
+    setTsSave("saved");
+    setTimeout(() => setTsSave("idle"), 1200);
+  }
+  async function saveExcluded(next: string[]) {
+    setExcluded(next);
+    setTsSave("saving");
+    const p = await api.getProject(project.id);
+    await api.updateProject(project.id, { config: { ...(p.config || {}), mcp_excluded_tools: next.length ? next : undefined } });
+    setTsSave("saved");
+    setTimeout(() => setTsSave("idle"), 1200);
+  }
+  const toggleToolExcluded = (tid: string) =>
+    saveExcluded(excluded.includes(tid) ? excluded.filter((x) => x !== tid) : [...excluded, tid]);
+  const toggleOpenSet = (id: string) =>
+    setOpenSets((prev) => { const n = new Set(prev); if (n.has(id)) n.delete(id); else n.add(id); return n; });
+
+  async function genToken() {
+    const t = await api.createMcpToken(project.id, {});
+    setNewToken(t.token || "");
+    api.listMcpTokens(project.id).then(setMcpTokens).catch(() => {});
+  }
+  async function revokeToken(id: string) {
+    await api.revokeMcpToken(project.id, id);
+    setMcpTokens((prev) => prev.filter((t) => t.id !== id));
+  }
+
   const activeMeta = CONN_SECTIONS.find((s) => s.id === section)!;
   return (
     <div className="col" style={{ flex: 1, minHeight: 0 }}>
@@ -167,7 +217,8 @@ export function ConnectScreen({ project }: { project: any }) {
             const on = section === s.id;
             return (
               <button key={s.id} onClick={() => setSection(s.id)} className={"sidenav-item" + (on ? " active" : "")}
-                style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", height: 34, padding: "0 10px", marginBottom: 1, borderRadius: 7, border: "none", cursor: "pointer", textAlign: "left", color: on ? "var(--accent)" : "var(--fg-1)", fontSize: 13, fontWeight: on ? 600 : 500, fontFamily: "var(--font-ui)" }}>
+                style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", height: 34, padding: "0 10px", paddingLeft: s.child ? 20 : 10, marginBottom: 1, borderRadius: 7, border: "none", cursor: "pointer", textAlign: "left", color: on ? "var(--accent)" : "var(--fg-1)", fontSize: 13, fontWeight: on ? 600 : 500, fontFamily: "var(--font-ui)" }}>
+                {s.child && <span aria-hidden style={{ color: "var(--fg-2)", fontSize: 13, lineHeight: 1, marginRight: -4, flex: "none" }}>└</span>}
                 <Icon name={s.icon as any} size={16} style={{ flex: "none" }} />
                 <span className="grow truncate">{s.label}</span>
               </button>
@@ -268,30 +319,123 @@ export function ConnectScreen({ project }: { project: any }) {
 
             {section === "mcp" && (
               <>
+        <Collapse title="How to use this MCP server" sub="Publish toolsets, connect a client, and pick how each user authenticates.">
+          <ol className="field-help" style={{ margin: "10px 0", paddingLeft: 18, lineHeight: 1.75 }}>
+            <li><b>Curate what&apos;s exposed.</b> Everything is published by default over the single endpoint below — under <b>Toolsets</b>, untick a whole set, or open a set and untick individual tools, to leave them out. (MCP shows the client a flat tool list; toolsets are just how you organize it.)</li>
+            <li><b>Set an API key</b> below — the shared server-to-server credential (<span className="mono-sm">Authorization: Bearer &lt;key&gt;</span>). Without a key the server is closed.</li>
+            <li><b>Add the endpoint</b> to your MCP client (Claude Desktop, Cursor, VS Code) with the config block below — that one URL is all a client needs.</li>
+            <li><b>Authenticate each user</b> — pick one: a <b>personal access token</b> (each user generates one below and pastes it into their client); <b>OAuth 2.1</b> (when enabled, the client discovers Forge and the user logs in — nothing to copy); or <b>your own backend</b> (mint a session token / use Connect and pass the user&apos;s session in <span className="mono-sm">X-Forge-Context</span>).</li>
+            <li><b>Act as the user downstream.</b> So a tool calls <em>your</em> app as that user, connect each user&apos;s account under <b>Auth providers</b> (Forge stores a per-user credential) or inject their session via <span className="mono-sm">{"{{ctx.*}}"}</span>. The MCP token itself is never forwarded. Your app owns its users &amp; sessions; Forge only carries the identity.</li>
+          </ol>
+        </Collapse>
         <div className="card" style={{ padding: 16, marginBottom: 14 }}>
           <div className="t-h3" style={{ marginBottom: 8 }}>MCP endpoint</div>
           <CodeBlock code={url} />
           <div className="field-help">JSON-RPC over HTTP (initialize / tools/list / tools/call) · authenticate with the API key below.</div>
         </div>
+        {/* Authentication: the API key and personal access token are alternatives - a client
+            pastes ONE of them as its Bearer token - so they live behind a two-tab switch. */}
         <div className="card" style={{ padding: 16, marginBottom: 14 }}>
-          <div className="row spread" style={{ marginBottom: 8 }}><div className="t-h3">API key</div><span className="t-caption fg-2">{save === "saving" ? "Saving…" : save === "saved" ? "Saved ✓" : ""}</span></div>
-          <div className="row gap2">
-            <input className="input mono" style={{ flex: 1 }} type="text" value={apiKey} onChange={(e) => setApiKey(e.target.value)} onBlur={(e) => saveKey(e.target.value)} placeholder="Set a key to expose the server" />
-            <button className="btn btn-secondary btn-sm" onClick={genKey}><Icon name="refresh" size={13} />Generate</button>
+          <div className="row spread" style={{ marginBottom: 10, alignItems: "center" }}>
+            <div className="t-h3">Authentication</div>
+            <Segmented options={[{ value: "key", label: "API key" }, { value: "pat", label: "Personal access token" }]} value={credTab} onChange={(v) => setCredTab(v as "key" | "pat")} />
           </div>
-          <div className="field-help">Required: clients send it as <span className="mono-sm">Authorization: Bearer &lt;key&gt;</span>. Without a key the endpoint is closed.</div>
+          <div className="field-help" style={{ marginBottom: 12 }}>Use <b>one</b> of these as the <span className="mono-sm">Bearer</span> token in the config below — the shared <b>API key</b> (server-to-server, one identity) <b>or</b> your own <b>personal access token</b> (acts as you).</div>
+          {credTab === "key" ? (
+            <div className="fade-in">
+              <div className="row gap2">
+                <input className="input mono" style={{ flex: 1 }} type="text" value={apiKey} onChange={(e) => setApiKey(e.target.value)} onBlur={(e) => saveKey(e.target.value)} placeholder="Set a key to expose the server" />
+                <button className="btn btn-secondary btn-sm" onClick={genKey}><Icon name="refresh" size={13} />Generate</button>
+                <span className="t-caption fg-2" style={{ alignSelf: "center", whiteSpace: "nowrap" }}>{save === "saving" ? "Saving…" : save === "saved" ? "Saved ✓" : ""}</span>
+              </div>
+              <div className="field-help">Shared server-to-server credential. Without a key the endpoint is closed to everyone.</div>
+            </div>
+          ) : (
+            <div className="fade-in">
+              <div className="field-help" style={{ marginBottom: 10 }}>
+                A per-user token to paste into your own MCP client instead of the shared key — the server then acts as <b>you</b> (your entitlements). Shown once on creation; store it safely.
+              </div>
+              {newToken && (
+                <div className="card" style={{ padding: 10, marginBottom: 10, background: "var(--bg-2)" }}>
+                  <div className="t-caption fg-2" style={{ marginBottom: 4 }}>New token — copy now, it won&apos;t be shown again:</div>
+                  <CodeBlock code={newToken} />
+                </div>
+              )}
+              <div className="row gap2" style={{ marginBottom: 10 }}>
+                <button className="btn btn-secondary btn-sm" onClick={genToken}><Icon name="plus" size={13} />Generate token</button>
+              </div>
+              <div className="col gap1">
+                {mcpTokens.map((t) => (
+                  <div key={t.id} className="row spread" style={{ padding: "6px 0", borderTop: "1px solid var(--line)" }}>
+                    <div className="row gap2" style={{ alignItems: "center", minWidth: 0 }}>
+                      <Icon name="auth" size={13} style={{ color: "var(--fg-2)" }} />
+                      <span className="mono-sm truncate">{t.name}</span>
+                      <span className="typechip">{t.prefix}…</span>
+                      {t.status !== "active" && <span className="pill pill-muted" style={{ height: 16 }}>{t.status}</span>}
+                    </div>
+                    {t.status === "active" && <button className="iconbtn" title="Revoke token" onClick={() => revokeToken(t.id)}><Icon name="trash" size={14} /></button>}
+                  </div>
+                ))}
+                {mcpTokens.length === 0 && <div className="fg-2 t-caption">No personal tokens yet.</div>}
+              </div>
+            </div>
+          )}
         </div>
         <div className="card" style={{ padding: 16, marginBottom: 14 }}>
           <div className="t-h3" style={{ marginBottom: 8 }}>Claude Desktop / Cursor config</div>
           <CodeBlock code={claudeConfig} />
         </div>
+        <div className="card" style={{ padding: 16, marginBottom: 14 }}>
+          <div className="row spread" style={{ marginBottom: 8 }}>
+            <div className="t-h3">Toolsets</div>
+            <span className="t-caption fg-2">{tsSave === "saving" ? "Saving…" : tsSave === "saved" ? "Saved ✓" : ""}</span>
+          </div>
+          <div className="field-help" style={{ marginBottom: 10 }}>
+            Everything is exposed by default over the single MCP endpoint above — untick a toolset, or open one and untick individual tools, to leave them out. Create and fill sets on the <b>Tools</b> screen.
+          </div>
+          {toolSets.length === 0 && <div className="fg-2 t-caption">No tool sets yet — create one on the Tools screen.</div>}
+          <div className="col gap1">
+            {toolSets.map((ts) => {
+              const open = openSets.has(ts.id);
+              const members = ts.tool_ids.map((id) => toolById.get(id)).filter(Boolean) as typeof tools;
+              const shown = ts.exposed ? members.filter((t) => !excluded.includes(t.id)).length : 0;
+              return (
+                <div key={ts.id} className="card" style={{ padding: 0, overflow: "hidden" }}>
+                  <div className="row spread" style={{ padding: "8px 10px", cursor: "pointer" }} onClick={() => toggleOpenSet(ts.id)}>
+                    <div className="row gap2" style={{ alignItems: "center", minWidth: 0 }}>
+                      <Icon name={open ? "chevdown" : "chevright"} size={14} style={{ color: "var(--fg-2)", flex: "none" }} />
+                      <span className="mono-sm truncate">{ts.name}</span>
+                      <span className="t-caption fg-2">{shown}/{members.length}</span>
+                      {!ts.exposed && <span className="pill pill-muted" style={{ height: 16 }}>excluded</span>}
+                    </div>
+                    <label className="row gap1" style={{ alignItems: "center", cursor: "pointer", flex: "none" }} onClick={(e) => e.stopPropagation()} title="Expose this whole toolset over MCP">
+                      <input type="checkbox" checked={ts.exposed} onChange={() => toggleExposed(ts)} />
+                      <span className="t-caption fg-2">Expose</span>
+                    </label>
+                  </div>
+                  {open && (
+                    <div className="col gap1" style={{ padding: "6px 12px 10px 30px", borderTop: "1px solid var(--line)" }}>
+                      {members.length === 0 && <div className="t-caption fg-2">No tools in this set yet.</div>}
+                      {members.map((t) => (
+                        <label key={t.id} className="row gap2" style={{ alignItems: "center", cursor: ts.exposed ? "pointer" : "default", opacity: ts.exposed ? 1 : 0.5 }}>
+                          <input type="checkbox" disabled={!ts.exposed} checked={ts.exposed && !excluded.includes(t.id)} onChange={() => toggleToolExcluded(t.id)} />
+                          <span className="mono-sm">{t.name}</span><span className="typechip">{t.kind}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
         <div className="card" style={{ padding: 16 }}>
-          <div className="t-h3" style={{ marginBottom: 10 }}>Exposed tools ({tools.filter((t) => t.enabled).length})</div>
+          <div className="t-h3" style={{ marginBottom: 10 }}>Currently exposed tools ({exposedTools.length})</div>
           <div className="col gap2">
-            {tools.map((t) => (
-              <div key={t.id} className="row gap2"><Icon name="tools" size={14} style={{ color: "var(--fg-2)" }} /><span className="mono-sm">{t.name}</span><span className="typechip">{t.kind}</span>{!t.enabled && <span className="pill pill-muted" style={{ height: 16 }}>disabled</span>}</div>
+            {exposedTools.map((t) => (
+              <div key={t.id} className="row gap2"><Icon name="tools" size={14} style={{ color: "var(--fg-2)" }} /><span className="mono-sm">{t.name}</span><span className="typechip">{t.kind}</span></div>
             ))}
-            {tools.length === 0 && <div className="fg-2 t-caption">No tools to expose yet - add some on the Tools screen.</div>}
+            {exposedTools.length === 0 && <div className="fg-2 t-caption">Nothing exposed yet — put tools in a set and toggle it on above.</div>}
           </div>
         </div>
               </>

--- a/apps/web/components/screens/settings.tsx
+++ b/apps/web/components/screens/settings.tsx
@@ -9,7 +9,7 @@ import { EmptyState, Field, Modal, Segmented, Tabs, Toggle } from "../primitives
 import { api, clearTokens, InviteResult, MeResult, ProjectVersion, Secret, TeamMember } from "@/lib/api";
 import { MODELS } from "@/lib/data";
 
-const ROLES = ["owner", "admin", "editor", "viewer"];
+const ROLES = ["owner", "admin", "editor", "viewer", "connector"];
 
 // Project default embedder when rag_defaults.embedding_model is unset. Matches the backend
 // default (embeddings._DEFAULT_FASTEMBED) and the project.json schema default.
@@ -69,6 +69,8 @@ export function SettingsScreen({ project, onDeleteProject }: { project: any; onD
   const [keySave, setKeySave] = useState<"idle" | "saving" | "saved">("idle");
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [tenantId, setTenantId] = useState("");
+  const [copiedWs, setCopiedWs] = useState(false);
 
   const reloadSecrets = useCallback(() => { if (project?.id) api.listSecrets(project.id).then(setSecrets).catch(() => {}); }, [project?.id]);
   useEffect(() => {
@@ -79,6 +81,9 @@ export function SettingsScreen({ project, onDeleteProject }: { project: any; onD
     }).catch(() => {});
     reloadSecrets();
   }, [project?.id, reloadSecrets]);
+  // The workspace (tenant) id — surfaced in General so a user whose email spans multiple
+  // workspaces can supply it at MCP OAuth login. Account-level, so it's independent of project.
+  useEffect(() => { api.me().then((m) => setTenantId(m.tenant_id || "")).catch(() => {}); }, []);
 
   const setCfg = (patch: Record<string, any>) => setConfig((c) => ({ ...c, ...patch }));
   const features = config.features || {};
@@ -173,6 +178,16 @@ export function SettingsScreen({ project, onDeleteProject }: { project: any; onD
                       <option value="fake:echo">fake:echo (offline)</option>
                       {MODELS.map((m) => <option key={m.id} value={m.id}>{m.name} · {m.provider}</option>)}
                     </select>
+                  </Field>
+                </Card>
+                <Card title="Workspace">
+                  <Field label="Workspace ID" help="Your workspace (tenant) identifier — account-level, NOT the project ID. You normally don't need it, but if you sign in over MCP OAuth and your email belongs to more than one workspace, paste this into the login screen's “Workspace id” field.">
+                    <div className="row gap2">
+                      <input className="input mono" readOnly value={tenantId} placeholder="…" onFocus={(e) => e.currentTarget.select()} style={{ flex: 1 }} />
+                      <button className="btn btn-secondary btn-sm" disabled={!tenantId} onClick={() => { if (tenantId) { navigator.clipboard?.writeText(tenantId); setCopiedWs(true); setTimeout(() => setCopiedWs(false), 1400); } }}>
+                        <Icon name={copiedWs ? "check" : "copy"} size={13} />{copiedWs ? "Copied" : "Copy"}
+                      </button>
+                    </div>
                   </Field>
                 </Card>
               </>

--- a/apps/web/components/screens/tools.tsx
+++ b/apps/web/components/screens/tools.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../icons";
 import { Field, Modal, Segmented, StatusPill, Tabs, Tile, TokenMeter, Toggle } from "../primitives";
 import { VersionHistory } from "../version-history";
-import { api, AuthProviderT, Tool, ToolTestResult } from "@/lib/api";
+import { api, AuthProviderT, Tool, ToolSet, ToolTestResult } from "@/lib/api";
 import { KIND_ICON, KIND_LABEL } from "@/lib/data";
 
 const estTokens = (o: any) => (o == null ? 0 : Math.max(1, JSON.stringify(o).length >> 2));
@@ -21,15 +21,26 @@ const DEFAULT_SAMPLE = {
 };
 
 /* ============ TOOLS LIST ============ */
+/* last_tested → [dot colour, label]. Untested reads amber (needs attention) per the design. */
+const STATUS = (s?: string | null): [string, string] =>
+  s === "pass" ? ["var(--ok)", "Passing"] : s === "fail" ? ["var(--err)", "Failing"] : ["var(--warn)", "Untested"];
+
 export function ToolsScreen({ project, onOpen }: { project: any; onOpen: (t: Tool) => void }) {
   const [tools, setTools] = useState<Tool[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [view, setView] = useState<"grid" | "list">("grid");
   const [open, setOpen] = useState(false);
+  const [toolSets, setToolSets] = useState<ToolSet[]>([]);
+  const [filterSet, setFilterSet] = useState<string>("all"); // "all" | "ungrouped" | <setId>
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerSel, setDrawerSel] = useState<string | null>(null); // null = create a new set
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState("");
 
   const reload = useCallback(() => {
     if (!project?.id) return;
     api.listTools(project.id).then(setTools).catch((e) => setErr(String(e.message || e)));
+    api.listToolSets(project.id).then(setToolSets).catch(() => {});
   }, [project?.id]);
   useEffect(() => { reload(); }, [reload]);
 
@@ -55,91 +66,352 @@ export function ToolsScreen({ project, onOpen }: { project: any; onOpen: (t: Too
     try { await api.updateTool(project.id, t.id, { enabled: !t.enabled }); } catch { reload(); }
   }
 
+  async function toggleToolInSet(setId: string, toolId: string, isMember: boolean) {
+    try {
+      if (isMember) await api.removeToolFromSet(project.id, setId, toolId);
+      else await api.addToolToSet(project.id, setId, toolId);
+    } finally {
+      reload();
+    }
+  }
+
+  const memberOf = useMemo(() => {
+    const m = new Set<string>();
+    toolSets.forEach((s) => s.tool_ids.forEach((id) => m.add(id)));
+    return m;
+  }, [toolSets]);
+  const ungroupedCount = useMemo(() => tools.filter((t) => !memberOf.has(t.id)).length, [tools, memberOf]);
+  const countFor = useCallback((s: ToolSet) => { const ids = new Set(s.tool_ids); return tools.filter((t) => ids.has(t.id)).length; }, [tools]);
+
+  const shown = useMemo(() => {
+    let list = tools;
+    if (filterSet === "ungrouped") list = tools.filter((t) => !memberOf.has(t.id));
+    else if (filterSet !== "all") { const ids = new Set(toolSets.find((x) => x.id === filterSet)?.tool_ids || []); list = tools.filter((t) => ids.has(t.id)); }
+    const q = query.trim().toLowerCase();
+    if (q) list = list.filter((t) => t.name.toLowerCase().includes(q) || String((t.config as any)?.description || "").toLowerCase().includes(q));
+    return list;
+  }, [tools, toolSets, filterSet, memberOf, query]);
+
+  const showCheckbox = filterSet === "all" || filterSet === "ungrouped";
+  const headingLabel = filterSet === "all" ? "Tools" : filterSet === "ungrouped" ? "Ungrouped tools" : (toolSets.find((s) => s.id === filterSet)?.name || "Tools");
+
+  function selectFilter(key: string) { setFilterSet(key); setSelected(new Set()); }
+  function toggleSelect(id: string) { setSelected((prev) => { const n = new Set(prev); if (n.has(id)) n.delete(id); else n.add(id); return n; }); }
+  function openManage() { setDrawerSel(filterSet !== "all" && filterSet !== "ungrouped" ? filterSet : (toolSets[0]?.id ?? null)); setDrawerOpen(true); }
+  function openNewSet() { setDrawerSel(null); setDrawerOpen(true); }
+
+  // Bulk-assign the current selection to a set (skipping tools already in it), then clear.
+  async function addSelectedToSet(setId: string) {
+    const already = new Set(toolSets.find((s) => s.id === setId)?.tool_ids || []);
+    const toAdd = Array.from(selected).filter((id) => !already.has(id));
+    try { await Promise.all(toAdd.map((id) => api.addToolToSet(project.id, setId, id))); }
+    finally { setSelected(new Set()); reload(); }
+  }
+
   return (
-    <div className="scroll-y" style={{ flex: 1, padding: "22px 28px" }}>
-      <div className="fade-up" style={{ maxWidth: 1600, margin: "0 auto" }}>
-        <div className="row spread" style={{ marginBottom: 18 }}>
-          <div>
-            <div className="t-display" style={{ fontSize: 21 }}>Tools</div>
-            <div className="fg-1" style={{ marginTop: 3, maxWidth: 560 }}>External capabilities - REST, GraphQL, code, SQL, or builtins - with response projection.</div>
-          </div>
-          <div className="row gap2">
-            <Segmented options={[{ value: "grid", label: "Grid" }, { value: "list", label: "List" }]} value={view} onChange={(v) => setView(v as any)} />
-            <button className="btn btn-primary" onClick={() => setOpen(true)}><Icon name="plus" size={15} />New tool</button>
+    <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+      <ToolsSidebar tools={tools} toolSets={toolSets} countFor={countFor} ungroupedCount={ungroupedCount} filterSet={filterSet} onFilter={selectFilter} onNewSet={openNewSet} onManage={openManage} />
+
+      <div className="col" style={{ flex: 1, minWidth: 0 }}>
+        <div className="scroll-y" style={{ flex: 1, padding: "24px 28px 120px" }}>
+          <div className="fade-up" style={{ maxWidth: 1500, margin: "0 auto" }}>
+            <div className="row spread wrap gap3" style={{ marginBottom: 22, alignItems: "flex-start" }}>
+              <div>
+                <div className="t-display" style={{ fontSize: 21 }}>{headingLabel}</div>
+                <div className="fg-2" style={{ marginTop: 4, maxWidth: 560 }}>External capabilities - REST, GraphQL, code, SQL, or builtins - with response projection.</div>
+              </div>
+              <div className="row gap2">
+                <input className="input" style={{ width: 190 }} placeholder="Search tools" value={query} onChange={(e) => setQuery(e.target.value)} />
+                <button className="btn btn-primary" onClick={() => setOpen(true)}><Icon name="plus" size={15} />New tool</button>
+                <Segmented options={[{ value: "grid", label: "Grid" }, { value: "list", label: "List" }]} value={view} onChange={(v) => setView(v as any)} />
+              </div>
+            </div>
+            {err && <div className="card" style={{ padding: 14, color: "var(--err)", marginBottom: 12 }}>{err}</div>}
+
+            {tools.length === 0 && !err ? (
+              <div className="card col center" style={{ padding: 44, gap: 8 }}><Tile icon="tools" color="var(--accent)" size={48} glow /><div className="t-h2">No tools yet</div><div className="fg-1">Create one, or ask the Forge Assistant to build it.</div></div>
+            ) : shown.length === 0 ? (
+              <div className="col center" style={{ padding: "60px 0", color: "var(--fg-2)", textAlign: "center" }}>
+                {filterSet === "ungrouped" ? "All tools are assigned to at least one toolset." : query ? "No tools match your search." : "No tools in this set yet."}
+              </div>
+            ) : view === "grid" ? (
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(280px,1fr))", gap: 16 }}>
+                {shown.map((t) => <ToolCard key={t.id} t={t} sets={toolSets} selectable={showCheckbox} selected={selected.has(t.id)} onToggleSelect={() => toggleSelect(t.id)} memberSetIds={new Set(toolSets.filter((s) => s.tool_ids.includes(t.id)).map((s) => s.id))} onToggleSet={(sid, isMember) => toggleToolInSet(sid, t.id, isMember)} onOpen={() => onOpen(t)} onDelete={(e) => del(e, t)} onDuplicate={(e) => duplicate(e, t)} onToggle={() => toggleEnabled(t)} />)}
+              </div>
+            ) : (
+              <div className="card" style={{ overflow: "hidden" }}>
+                <table className="tbl">
+                  <thead><tr>{showCheckbox && <th style={{ width: 34 }}></th>}<th>Tool</th><th>Kind</th><th>Auth</th><th>Projection</th><th>Status</th><th></th></tr></thead>
+                  <tbody>
+                    {shown.map((t) => {
+                      const lt = (t.config as any)?._last_test;
+                      return (
+                        <tr key={t.id} className="row" style={{ cursor: "pointer" }} onClick={() => onOpen(t)}>
+                          {showCheckbox && <td onClick={(e) => { e.stopPropagation(); toggleSelect(t.id); }}><Checkbox checked={selected.has(t.id)} /></td>}
+                          <td><div className="row gap2"><Icon name={KIND_ICON[t.kind] || "k_rest"} size={15} style={{ color: "var(--accent)" }} /><span className="mono-sm" style={{ fontWeight: 600 }}>{t.name}</span></div></td>
+                          <td><span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span></td>
+                          <td>{t.auth_provider_id ? <span className="chip chip-mono"><Icon name="auth" size={12} />{t.auth_provider_id.slice(0, 8)}</span> : <span className="fg-2">-</span>}</td>
+                          <td>{lt ? <TokenMeter compact raw={lt.raw_tokens} projected={lt.projected_tokens} animateKey={t.id} /> : <span className="fg-2">-</span>}</td>
+                          <td><StatusPill status={t.last_tested || "untested"} /></td>
+                          <td style={{ textAlign: "right" }}>
+                            <div className="row gap1" style={{ justifyContent: "flex-end" }}>
+                              <Toggle on={t.enabled} onChange={() => toggleEnabled(t)} />
+                              <button className="iconbtn" title="Duplicate tool" onClick={(e) => duplicate(e, t)}><Icon name="copy" size={14} /></button>
+                              <button className="iconbtn" title="Delete tool" onClick={(e) => { e.stopPropagation(); del(e, t); }}><Icon name="trash" size={14} /></button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
         </div>
-        {err && <div className="card" style={{ padding: 14, color: "var(--err)", marginBottom: 12 }}>{err}</div>}
-
-        {tools.length === 0 && !err && (
-          <div className="card col center" style={{ padding: 44, gap: 8 }}><Tile icon="tools" color="var(--accent)" size={48} glow /><div className="t-h2">No tools yet</div><div className="fg-1">Create one, or ask the Forge Assistant to build it.</div></div>
-        )}
-
-        {view === "grid" ? (
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(300px,1fr))", gap: 14 }}>
-            {tools.map((t) => <ToolCard key={t.id} t={t} onOpen={() => onOpen(t)} onDelete={(e) => del(e, t)} onDuplicate={(e) => duplicate(e, t)} onToggle={() => toggleEnabled(t)} />)}
-          </div>
-        ) : (
-          <div className="card" style={{ overflow: "hidden" }}>
-            <table className="tbl">
-              <thead><tr><th>Tool</th><th>Kind</th><th>Auth</th><th>Projection</th><th>Status</th><th></th></tr></thead>
-              <tbody>
-                {tools.map((t) => {
-                  const lt = (t.config as any)?._last_test;
-                  return (
-                    <tr key={t.id} className="row" style={{ cursor: "pointer" }} onClick={() => onOpen(t)}>
-                      <td><div className="row gap2"><Icon name={KIND_ICON[t.kind] || "k_rest"} size={15} style={{ color: "var(--accent)" }} /><span className="mono-sm" style={{ fontWeight: 600 }}>{t.name}</span></div></td>
-                      <td><span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span></td>
-                      <td>{t.auth_provider_id ? <span className="chip chip-mono"><Icon name="auth" size={12} />{t.auth_provider_id.slice(0, 8)}</span> : <span className="fg-2">-</span>}</td>
-                      <td>{lt ? <TokenMeter compact raw={lt.raw_tokens} projected={lt.projected_tokens} animateKey={t.id} /> : <span className="fg-2">-</span>}</td>
-                      <td><StatusPill status={t.last_tested || "untested"} /></td>
-                      <td style={{ textAlign: "right" }}>
-                        <div className="row gap1" style={{ justifyContent: "flex-end" }}>
-                          <Toggle on={t.enabled} onChange={() => toggleEnabled(t)} />
-                          <button className="iconbtn" title="Duplicate tool" onClick={(e) => duplicate(e, t)}><Icon name="copy" size={14} /></button>
-                          <button className="iconbtn" title="Delete tool" onClick={(e) => { e.stopPropagation(); del(e, t); }}><Icon name="trash" size={14} /></button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
       </div>
+
+      {selected.size > 0 && <SelectionBar count={selected.size} toolSets={toolSets} onAddTo={addSelectedToSet} onClear={() => setSelected(new Set())} />}
 
       <NewToolModal project={project} open={open} onClose={() => setOpen(false)} onOpenTool={onOpen} onReload={reload} />
+      <ManageToolsetsDrawer project={project} tools={tools} toolSets={toolSets} open={drawerOpen} initialSel={drawerSel} onClose={() => setDrawerOpen(false)} onChanged={reload} />
     </div>
   );
 }
 
-function ToolCard({ t, onOpen, onDelete, onDuplicate, onToggle }: { t: Tool; onOpen: () => void; onDelete: (e: React.MouseEvent) => void; onDuplicate: (e: React.MouseEvent) => void; onToggle: () => void }) {
-  const proj = (t.config as any)?.response?.projection_jmespath || (t.config as any)?.response?.projection;
+/* ============ TOOLS SIDEBAR (All / Ungrouped / colour-coded toolsets) ============ */
+function Checkbox({ checked }: { checked: boolean }) {
   return (
-    <div className="card card-hover" style={{ padding: 15, opacity: t.enabled ? 1 : 0.6 }} onClick={onOpen}>
-      <div className="row spread" style={{ marginBottom: 10 }}>
-        <span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span>
-        <div className="row gap2" style={{ alignItems: "center" }}>
-          <StatusPill status={t.last_tested || "untested"} />
-          <ToolCardMenu enabled={t.enabled} onToggle={onToggle} onDuplicate={onDuplicate} onDelete={onDelete} />
+    <div style={{ width: 16, height: 16, borderRadius: 4, flex: "none", border: `1.5px solid ${checked ? "var(--accent)" : "var(--line-strong)"}`, background: checked ? "var(--accent)" : "var(--bg-1)", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
+      {checked && <Icon name="check" size={11} style={{ color: "var(--fg-on-accent)" }} />}
+    </div>
+  );
+}
+
+function SideItem({ label, count, active, onClick, alert }: { label: string; count: number; active: boolean; onClick: () => void; alert?: boolean }) {
+  return (
+    <div onClick={onClick} className="sidenav-item" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 10px", borderRadius: 8, cursor: "pointer", fontWeight: 600, fontSize: 13.5, background: active ? "var(--accent-glow)" : undefined, color: active ? "var(--accent)" : "var(--fg-0)" }}>
+      <span style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <span className="truncate">{label}</span>
+        {alert && <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--warn)", flex: "none" }} />}
+      </span>
+      <span style={{ fontSize: 12, fontWeight: 500, color: "var(--fg-2)", flex: "none" }}>{count}</span>
+    </div>
+  );
+}
+
+function ToolsSidebar({ tools, toolSets, countFor, ungroupedCount, filterSet, onFilter, onNewSet, onManage }: { tools: Tool[]; toolSets: ToolSet[]; countFor: (s: ToolSet) => number; ungroupedCount: number; filterSet: string; onFilter: (k: string) => void; onNewSet: () => void; onManage: () => void }) {
+  return (
+    <div className="col" style={{ width: 236, flex: "0 0 236px", background: "var(--bg-1)", borderRight: "1px solid var(--line)", padding: "20px 14px", gap: 22, overflowY: "auto" }}>
+      <div className="t-h1" style={{ padding: "0 8px" }}>MCP Tools</div>
+
+      <div className="col" style={{ gap: 2 }}>
+        <SideItem label="All tools" count={tools.length} active={filterSet === "all"} onClick={() => onFilter("all")} />
+        <SideItem label="Ungrouped" count={ungroupedCount} active={filterSet === "ungrouped"} onClick={() => onFilter("ungrouped")} alert={ungroupedCount > 0} />
+      </div>
+
+      <div className="col" style={{ gap: 6 }}>
+        <div className="row spread" style={{ padding: "0 10px" }}>
+          <span className="t-micro">Toolsets</span>
+          <button className="iconbtn" title="New toolset" onClick={onNewSet} style={{ width: 22, height: 22 }}><Icon name="plus" size={14} /></button>
+        </div>
+        {toolSets.map((s) => (
+          <SideItem key={s.id} label={s.name} count={countFor(s)} active={filterSet === s.id} onClick={() => onFilter(s.id)} />
+        ))}
+        {toolSets.length === 0 && <div className="fg-2 t-caption" style={{ padding: "2px 10px" }}>No toolsets yet.</div>}
+        <button onClick={onManage} className="btn btn-ghost btn-sm" style={{ marginTop: 4, justifyContent: "center", border: "1px dashed var(--line-strong)" }}>Manage toolsets</button>
+      </div>
+
+      <div style={{ marginTop: "auto", padding: 10, background: "var(--bg-3)", borderRadius: 8, fontSize: 12, color: "var(--fg-2)", lineHeight: 1.5 }}>
+        A tool can belong to any number of toolsets - assign it from its card, bulk-select, or Manage toolsets.
+      </div>
+    </div>
+  );
+}
+
+/* Bulk-action bar (fixed, bottom-centre) shown while tools are multi-selected. */
+function SelectionBar({ count, toolSets, onAddTo, onClear }: { count: number; toolSets: ToolSet[]; onAddTo: (setId: string) => void; onClear: () => void }) {
+  const [menu, setMenu] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!menu) return;
+    const h = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setMenu(false); };
+    window.addEventListener("mousedown", h);
+    return () => window.removeEventListener("mousedown", h);
+  }, [menu]);
+  return (
+    <div className="fade-up row gap3" style={{ position: "fixed", bottom: 24, left: "50%", transform: "translateX(-50%)", background: "var(--fg-0)", color: "var(--bg-1)", borderRadius: 12, padding: "10px 14px", boxShadow: "var(--sh-pop)", zIndex: 5000 }}>
+      <span style={{ fontSize: 13, fontWeight: 600 }}>{count} selected</span>
+      <div ref={ref} style={{ position: "relative" }}>
+        <button onClick={() => setMenu((m) => !m)} style={{ fontSize: 13, fontWeight: 600, padding: "7px 12px", borderRadius: 8, background: "var(--bg-hover)", color: "var(--fg-0)", border: "none", cursor: "pointer", fontFamily: "var(--font-ui)" }}>Add to toolset ▾</button>
+        {menu && (
+          <div className="card" style={{ position: "absolute", bottom: "calc(100% + 8px)", left: 0, minWidth: 200, padding: 6, boxShadow: "var(--sh-pop)" }}>
+            {toolSets.length === 0 && <div className="fg-2 t-caption" style={{ padding: "8px 10px" }}>No toolsets yet.</div>}
+            {toolSets.map((s) => (
+              <button key={s.id} onClick={() => { setMenu(false); onAddTo(s.id); }} className="truncate" style={{ width: "100%", textAlign: "left", padding: "8px 10px", border: "none", background: "none", borderRadius: 6, cursor: "pointer", fontSize: 13, color: "var(--fg-0)", fontFamily: "var(--font-ui)" }}>{s.name}</button>
+            ))}
+          </div>
+        )}
+      </div>
+      <button onClick={onClear} style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-2)", background: "none", border: "none", cursor: "pointer", fontFamily: "var(--font-ui)" }}>Cancel</button>
+    </div>
+  );
+}
+
+/* ============ MANAGE TOOLSETS (right drawer: set list + editor) ============ */
+function ManageToolsetsDrawer({ project, tools, toolSets, open, initialSel, onClose, onChanged }: { project: any; tools: Tool[]; toolSets: ToolSet[]; open: boolean; initialSel: string | null; onClose: () => void; onChanged: () => void }) {
+  const [sel, setSel] = useState<string | null>(initialSel); // null = creating a new set
+  const [name, setName] = useState("");
+  const [desc, setDesc] = useState("");
+  const [memberIds, setMemberIds] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const addRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => { if (open) setSel(initialSel); }, [open, initialSel]);
+  useEffect(() => {
+    if (sel == null) { setName(""); setDesc(""); setMemberIds([]); return; }
+    const s = toolSets.find((x) => x.id === sel);
+    if (s) { setName(s.name); setDesc(s.description || ""); setMemberIds(s.tool_ids); }
+  }, [sel, toolSets]);
+  useEffect(() => {
+    if (!addOpen) return;
+    const h = (e: MouseEvent) => { if (addRef.current && !addRef.current.contains(e.target as Node)) setAddOpen(false); };
+    window.addEventListener("mousedown", h);
+    return () => window.removeEventListener("mousedown", h);
+  }, [addOpen]);
+
+  const saved = toolSets.find((x) => x.id === sel)?.tool_ids || [];
+  // The list shows only tools that belong to the set - plus any member you just unchecked,
+  // kept visible (unchecked) until you Save, at which point it drops off. Unrelated tools
+  // are never listed here; add them from the "Add tools" picker.
+  const visibleIds = useMemo(() => new Set([...saved, ...memberIds]), [saved, memberIds]);
+  const memberList = tools.filter((t) => visibleIds.has(t.id));
+  const addable = tools.filter((t) => !visibleIds.has(t.id));
+  const addMember = (tid: string) => setMemberIds((m) => (m.includes(tid) ? m : [...m, tid]));
+  const toggleMember = (tid: string) => setMemberIds((m) => (m.includes(tid) ? m.filter((x) => x !== tid) : [...m, tid]));
+
+  async function save() {
+    setBusy(true);
+    try {
+      if (sel == null) { const s = await api.createToolSet(project.id, { name: name.trim() || "new_toolset", description: desc, tool_ids: memberIds }); setSel(s.id); }
+      else await api.updateToolSet(project.id, sel, { name, description: desc, tool_ids: memberIds });
+      onChanged();
+    } finally { setBusy(false); }
+  }
+  async function del() {
+    if (sel == null) return;
+    if (!window.confirm("Delete this tool set? The tools themselves are not deleted.")) return;
+    await api.deleteToolSet(project.id, sel);
+    setSel(null); onChanged();
+  }
+
+  return (
+    <div style={{ position: "fixed", inset: 0, zIndex: 7000, pointerEvents: open ? "auto" : "none" }}>
+      <div onClick={onClose} style={{ position: "absolute", inset: 0, background: "rgba(8,10,14,.4)", opacity: open ? 1 : 0, transition: "opacity var(--dur)" }} />
+      <div className="row" style={{ position: "absolute", top: 0, right: 0, bottom: 0, width: 640, maxWidth: "96vw", background: "var(--bg-1)", borderLeft: "1px solid var(--line)", boxShadow: "var(--sh-pop)", transform: open ? "none" : "translateX(100%)", transition: "transform var(--dur-slow) var(--ease)", alignItems: "stretch" }}>
+        <div className="col" style={{ width: 210, flex: "0 0 210px", borderRight: "1px solid var(--line)", padding: "20px 12px", gap: 4, overflowY: "auto" }}>
+          <div className="t-h1" style={{ padding: "4px 8px 12px" }}>Toolsets</div>
+          {toolSets.map((s) => {
+            const active = sel === s.id;
+            return (
+              <div key={s.id} onClick={() => setSel(s.id)} className="sidenav-item" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "9px 10px", borderRadius: 8, cursor: "pointer", background: active ? "var(--accent-glow)" : undefined }}>
+                <span className="truncate" style={{ minWidth: 0, fontSize: 13, fontWeight: 600, color: active ? "var(--accent)" : "var(--fg-0)" }}>{s.name}</span>
+                <span className="fg-2 t-caption">{s.tool_ids.length}</span>
+              </div>
+            );
+          })}
+          <button onClick={() => setSel(null)} className="btn btn-ghost btn-sm" style={{ marginTop: 6, justifyContent: "flex-start", color: sel == null ? "var(--accent)" : "var(--fg-1)" }}><Icon name="plus" size={13} />New toolset</button>
+        </div>
+
+        {/* Right editor pane: header + fields + list header stay put; only the member list
+            scrolls, and the action row is pinned to the bottom. */}
+        <div className="col grow" style={{ minWidth: 0, minHeight: 0 }}>
+          <div style={{ position: "relative", zIndex: 3, padding: "22px 24px 0" }}>
+            <div className="row spread" style={{ marginBottom: 16 }}>
+              <div className="t-h1">{sel == null ? "New toolset" : name || "Toolset"}</div>
+              <button className="iconbtn" onClick={onClose}><Icon name="x" size={17} /></button>
+            </div>
+            <Field label="Name"><input className="input" value={name} onChange={(e) => setName(e.target.value)} placeholder="quoting_tools" /></Field>
+            <Field label="Description" help="Shown to MCP clients/agents to describe what the set is for."><input className="input" value={desc} onChange={(e) => setDesc(e.target.value)} /></Field>
+
+            <div className="row spread" style={{ margin: "6px 0 8px", alignItems: "center" }}>
+              <span className="t-micro">Tools in this set - {memberIds.length}</span>
+              <div ref={addRef} style={{ position: "relative" }}>
+                <button className="btn btn-ghost btn-sm" onClick={() => setAddOpen((o) => !o)} disabled={addable.length === 0}><Icon name="plus" size={13} />Add tools</button>
+                {addOpen && addable.length > 0 && (
+                  <div className="card fade-in" style={{ position: "absolute", top: "calc(100% + 4px)", right: 0, zIndex: 10, minWidth: 260, maxHeight: 280, overflowY: "auto", padding: 4, boxShadow: "var(--sh-pop)" }}>
+                    {addable.map((t) => (
+                      <button key={t.id} onClick={() => addMember(t.id)} className="row spread gap2" style={{ width: "100%", padding: "7px 9px", border: "none", background: "none", borderRadius: 6, cursor: "pointer", fontFamily: "var(--font-ui)" }}>
+                        <span className="mono-sm truncate" style={{ fontWeight: 600 }}>{t.name}</span>
+                        <span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="scroll-y" style={{ flex: 1, minHeight: 0, padding: "0 24px 8px" }}>
+            <div className="col" style={{ border: "1px solid var(--line)", borderRadius: 10, overflow: "hidden" }}>
+              {memberList.map((t, i) => (
+                <div key={t.id} onClick={() => toggleMember(t.id)} className="row gap2" style={{ padding: "10px 12px", borderBottom: i < memberList.length - 1 ? "1px solid var(--line)" : "none", cursor: "pointer" }}>
+                  <Checkbox checked={memberIds.includes(t.id)} />
+                  <span className="mono-sm" style={{ fontWeight: 600, flex: 1, minWidth: 0 }}>{t.name}</span>
+                  <span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span>
+                </div>
+              ))}
+              {memberList.length === 0 && <div className="fg-2 t-caption" style={{ padding: 14 }}>No tools in this set yet — use “Add tools”.</div>}
+            </div>
+          </div>
+
+          <div className="row spread" style={{ padding: "12px 24px", borderTop: "1px solid var(--line)", flex: "none" }}>
+            {sel != null ? <button className="btn btn-ghost btn-sm" style={{ color: "var(--err)" }} onClick={del}><Icon name="trash" size={13} />Delete set</button> : <span />}
+            <div className="row gap2">
+              <button className="btn btn-ghost btn-sm" onClick={onClose}>Close</button>
+              <button className="btn btn-primary btn-sm" onClick={save} disabled={busy}>{busy ? "Saving…" : "Save set"}</button>
+            </div>
+          </div>
         </div>
       </div>
-      <div className="mono" style={{ fontWeight: 600, fontSize: 13.5, color: "var(--fg-0)", overflowWrap: "anywhere", wordBreak: "break-word" }}>{t.name}</div>
-      <div className="fg-2 t-caption" style={{ marginTop: 3, height: 32, overflow: "hidden" }}>{(t.config as any)?.description || "No description."}</div>
-      <div className="divider" style={{ margin: "10px 0" }} />
-      <div className="row spread" style={{ fontSize: 10.5, color: "var(--fg-2)", minHeight: 20, alignItems: "center" }}>
-        <span className="row gap1"><Icon name={proj ? "check" : "minus"} size={12} />{proj ? "Response projection set" : "No projection"}</span>
-        {t.auth_provider_id && <span className="row gap1 truncate" style={{ maxWidth: 130 }}><Icon name="auth" size={11} />{t.auth_provider_id.slice(0, 10)}</span>}
-      </div>
     </div>
   );
 }
 
-/* Overflow menu on each tool card - enable/disable toggle, duplicate, delete.
-   Drops DOWN from the trigger, right-aligned so it never runs off-screen. */
-function ToolCardMenu({ enabled, onToggle, onDuplicate, onDelete }: { enabled: boolean; onToggle: () => void; onDuplicate: (e: React.MouseEvent) => void; onDelete: (e: React.MouseEvent) => void }) {
+function ToolCard({ t, sets, selectable, selected, onToggleSelect, memberSetIds, onToggleSet, onOpen, onDelete, onDuplicate, onToggle }: { t: Tool; sets: ToolSet[]; selectable: boolean; selected: boolean; onToggleSelect: () => void; memberSetIds: Set<string>; onToggleSet: (setId: string, isMember: boolean) => void; onOpen: () => void; onDelete: (e: React.MouseEvent) => void; onDuplicate: (e: React.MouseEvent) => void; onToggle: () => void }) {
+  const [statusColor, statusLabel] = STATUS(t.last_tested);
+  const [menuOpen, setMenuOpen] = useState(false);
+  return (
+    // While its ••• menu is open the card is lifted above its grid siblings, so the dropdown
+    // (which overflows the card bounds) isn't painted under the neighbouring cards.
+    <div className="card card-hover" style={{ padding: 16, position: "relative", zIndex: menuOpen ? 30 : undefined, opacity: t.enabled ? 1 : 0.6, borderColor: selected ? "var(--accent)" : undefined }} onClick={onOpen}>
+      <div className="row spread" style={{ marginBottom: 12 }}>
+        <div className="row gap2">
+          {selectable && <div onClick={(e) => { e.stopPropagation(); onToggleSelect(); }}><Checkbox checked={selected} /></div>}
+          <span className="chip chip-mono">{KIND_LABEL[t.kind] || t.kind}</span>
+        </div>
+        <div className="row gap2" style={{ alignItems: "center" }}>
+          <span style={{ width: 7, height: 7, borderRadius: "50%", background: statusColor, flex: "none" }} />
+          <span className="t-caption fg-1">{statusLabel}</span>
+          <ToolCardMenu enabled={t.enabled} sets={sets} memberSetIds={memberSetIds} onToggleSet={onToggleSet} onToggle={onToggle} onDuplicate={onDuplicate} onDelete={onDelete} onOpenChange={setMenuOpen} />
+        </div>
+      </div>
+      <div className="mono" style={{ fontWeight: 700, fontSize: 14, color: "var(--fg-0)", overflowWrap: "anywhere", wordBreak: "break-word", marginBottom: 6 }}>{t.name}</div>
+      {/* Clamp to 2 lines with a fixed height so cards stay uniform regardless of how long
+          a tool's description is (grid rows otherwise stretch to the tallest card). */}
+      <div className="fg-1 t-caption" style={{ lineHeight: "18px", height: 36, overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>{(t.config as any)?.description || "No description."}</div>
+    </div>
+  );
+}
+
+/* Overflow menu on each tool card - enable/disable toggle, per-set membership toggles
+   (colour-coded to match the sidebar), duplicate, delete. Drops DOWN from the trigger,
+   right-aligned so it never runs off-screen. */
+function ToolCardMenu({ enabled, sets, memberSetIds, onToggleSet, onToggle, onDuplicate, onDelete, onOpenChange }: { enabled: boolean; sets: ToolSet[]; memberSetIds: Set<string>; onToggleSet: (setId: string, isMember: boolean) => void; onToggle: () => void; onDuplicate: (e: React.MouseEvent) => void; onDelete: (e: React.MouseEvent) => void; onOpenChange?: (open: boolean) => void }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => { onOpenChange?.(open); }, [open, onOpenChange]);
   useEffect(() => {
     if (!open) return;
     const h = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
@@ -151,11 +423,22 @@ function ToolCardMenu({ enabled, onToggle, onDuplicate, onDelete }: { enabled: b
     <div ref={ref} style={{ position: "relative" }} onClick={(e) => e.stopPropagation()}>
       <button className={"iconbtn" + (open ? " active" : "")} title="More actions" aria-haspopup="menu" aria-expanded={open} onClick={() => setOpen((o) => !o)}><Icon name="more" size={16} /></button>
       {open && (
-        <div className="card fade-in" role="menu" style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, zIndex: 6000, minWidth: 172, padding: 4, boxShadow: "var(--sh-pop)" }}>
+        <div className="card fade-in" role="menu" style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, zIndex: 6000, minWidth: 190, padding: 4, boxShadow: "var(--sh-pop)" }}>
           <div style={{ ...item, justifyContent: "space-between", color: "var(--fg-1)", cursor: "default" }}>
             <span className="row gap2"><Icon name="bolt" size={15} style={{ color: enabled ? "var(--signal)" : "var(--fg-2)" }} />{enabled ? "Enabled" : "Disabled"}</span>
             <Toggle on={enabled} onChange={onToggle} />
           </div>
+          <div className="divider" style={{ margin: "4px 0" }} />
+          <div className="t-micro" style={{ padding: "4px 9px 2px" }}>Tool sets</div>
+          {sets.length > 0 ? sets.map((s) => {
+            const member = memberSetIds.has(s.id);
+            return (
+              <button key={s.id} role="menuitemcheckbox" aria-checked={member} style={{ ...item, color: "var(--fg-1)", justifyContent: "space-between" }} onClick={() => onToggleSet(s.id, member)}>
+                <span className="truncate">{s.name}</span>
+                {member && <Icon name="check" size={14} style={{ color: "var(--accent)" }} />}
+              </button>
+            );
+          }) : <div style={{ padding: "2px 9px 6px", color: "var(--fg-2)", fontSize: 12 }}>Not in any toolset</div>}
           <div className="divider" style={{ margin: "4px 0" }} />
           <button role="menuitem" style={{ ...item, color: "var(--fg-1)" }} onClick={(e) => { setOpen(false); onDuplicate(e); }}><Icon name="copy" size={15} />Duplicate</button>
           <button role="menuitem" style={{ ...item, color: "var(--err)" }} onClick={(e) => { setOpen(false); onDelete(e); }}><Icon name="trash" size={15} />Delete</button>

--- a/apps/web/components/screens/workflows.tsx
+++ b/apps/web/components/screens/workflows.tsx
@@ -16,7 +16,7 @@ import { FieldsForm, ModelSelect, MultiSelectChips, type FieldSpec } from "../ca
 import { Field, Toggle } from "../primitives";
 import { VersionHistory } from "../version-history";
 import type { ComponentT } from "@/lib/api";
-import { api, openSSE, Agent, McpClientT, NodeType, Tool, Workflow } from "@/lib/api";
+import { api, openSSE, Agent, McpClientT, NodeType, Tool, ToolSet, Workflow } from "@/lib/api";
 import { NODE_META, NODE_HELP, IO_COLOR, fmtUSD } from "@/lib/data";
 import { canvasToExecutable, canvasToFlow, ioCompatible, newNodeId, starterWorkflow, type FlowEdge, type FlowNode } from "@/lib/graph";
 
@@ -223,6 +223,7 @@ function CanvasInner({ project, workflowId, onWorkflowChange, onBack, onRun, onR
   const [wf, setWf] = useState<Workflow | null>(null);
   const [registry, setRegistry] = useState<Record<string, NodeType>>({});
   const [tools, setTools] = useState<Tool[]>([]);
+  const [toolSets, setToolSets] = useState<ToolSet[]>([]);
   // Saved agent presets (from the Agents tab) - loadable into an agent node.
   const [agents, setAgents] = useState<Agent[]>([]);
   const [mcpServers, setMcpServers] = useState<McpClientT[]>([]);
@@ -261,6 +262,7 @@ function CanvasInner({ project, workflowId, onWorkflowChange, onBack, onRun, onR
     api.listNodeTypes().then((nt) => setRegistry(Object.fromEntries(nt.map((n) => [n.type, n])))).catch(() => {});
     if (project?.id) {
       api.listTools(project.id).then(setTools).catch(() => {});
+      api.listToolSets(project.id).then(setToolSets).catch(() => {});
       api.listAgents(project.id).then(setAgents).catch(() => {});
       api.listMcpClients(project.id).then(setMcpServers).catch(() => {});
       api.listComponents(project.id).then(setComponents).catch(() => {});
@@ -837,6 +839,7 @@ function CanvasInner({ project, workflowId, onWorkflowChange, onBack, onRun, onR
               node={selected}
               nodes={nodes}
               tools={tools}
+              toolSets={toolSets}
               agents={agents}
               mcpServers={mcpServers}
               components={components}
@@ -869,6 +872,7 @@ function NodeInspector({
   node,
   nodes,
   tools,
+  toolSets,
   agents,
   mcpServers,
   components,
@@ -883,6 +887,7 @@ function NodeInspector({
   node: FlowNode;
   nodes: FlowNode[];
   tools: Tool[];
+  toolSets: ToolSet[];
   agents: Agent[];
   mcpServers: McpClientT[];
   components: ComponentT[];
@@ -913,7 +918,7 @@ function NodeInspector({
         <button className="btn btn-danger btn-sm" onClick={() => onDelete(node.id)}><Icon name="trash" size={14} />Delete</button>
       </div>
 
-      {(type === "agent" || type === "deep_agent") && <AgentConfig config={c} onChange={onChange} tools={tools} agents={agents} mcpServers={mcpServers} components={components} folders={dynamic?.kb_folders || []} kinds={dynamic?.qa_kinds || []} />}
+      {(type === "agent" || type === "deep_agent") && <AgentConfig config={c} onChange={onChange} tools={tools} toolSets={toolSets} agents={agents} mcpServers={mcpServers} components={components} folders={dynamic?.kb_folders || []} kinds={dynamic?.qa_kinds || []} />}
 
       {type === "retrieval" && <RetrievalForm c={c} set={set} folders={dynamic?.kb_folders || []} kinds={dynamic?.qa_kinds || []} />}
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -56,6 +56,30 @@ export interface Tool {
   config: Record<string, any>;
 }
 
+export interface ToolSet {
+  id: string;
+  project_id: string;
+  name: string;
+  slug: string;
+  description: string;
+  icon?: string | null;
+  is_default: boolean;
+  exposed: boolean;
+  tool_ids: string[];
+}
+
+export interface McpToken {
+  id: string;
+  name: string;
+  prefix: string;
+  project_id?: string | null;
+  status: string;
+  created_at?: string | null;
+  last_used_at?: string | null;
+  expires_at?: string | null;
+  token?: string | null;
+}
+
 export interface ComponentT {
   id: string;
   name: string;
@@ -292,6 +316,24 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ args, context }),
     }),
+  // tool sets (describable groups of tools; organize the Tools screen + publish over MCP)
+  listToolSets: (pid: string) => json<ToolSet[]>(`/v1/projects/${pid}/tool-sets`),
+  createToolSet: (pid: string, body: { name: string; description?: string; icon?: string | null; is_default?: boolean; exposed?: boolean; tool_ids?: string[] }) =>
+    json<ToolSet>(`/v1/projects/${pid}/tool-sets`, { method: "POST", body: JSON.stringify(body) }),
+  updateToolSet: (pid: string, sid: string, body: Partial<{ name: string; description: string; icon: string | null; is_default: boolean; exposed: boolean; tool_ids: string[] }>) =>
+    json<ToolSet>(`/v1/projects/${pid}/tool-sets/${sid}`, { method: "PATCH", body: JSON.stringify(body) }),
+  deleteToolSet: (pid: string, sid: string) =>
+    fetch(`${BASE}/v1/projects/${pid}/tool-sets/${sid}`, { method: "DELETE", headers: authHeader() }),
+  addToolToSet: (pid: string, sid: string, tid: string) =>
+    fetch(`${BASE}/v1/projects/${pid}/tool-sets/${sid}/tools/${tid}`, { method: "POST", headers: authHeader() }),
+  removeToolFromSet: (pid: string, sid: string, tid: string) =>
+    fetch(`${BASE}/v1/projects/${pid}/tool-sets/${sid}/tools/${tid}`, { method: "DELETE", headers: authHeader() }),
+  // MCP personal access tokens (per-user MCP auth; the plaintext is returned once on create)
+  listMcpTokens: (pid: string) => json<McpToken[]>(`/v1/projects/${pid}/mcp-tokens`),
+  createMcpToken: (pid: string, body: { name?: string; ttl_days?: number }) =>
+    json<McpToken>(`/v1/projects/${pid}/mcp-tokens`, { method: "POST", body: JSON.stringify(body) }),
+  revokeMcpToken: (pid: string, tid: string) =>
+    fetch(`${BASE}/v1/projects/${pid}/mcp-tokens/${tid}`, { method: "DELETE", headers: authHeader() }),
   // components (Feature 2 - generative UI widgets)
   listComponents: (pid: string) => json<ComponentT[]>(`/v1/projects/${pid}/components`),
   getComponent: (pid: string, cid: string) => json<ComponentT>(`/v1/projects/${pid}/components/${cid}`),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,13 @@ services:
       FORGE_PUBLIC_BASE_URL: ${FORGE_PUBLIC_BASE_URL:-http://localhost:8000}
       FORGE_PUBLIC_CONSOLE_URL: ${FORGE_PUBLIC_CONSOLE_URL:-http://localhost:3000}
       FORGE_CORS_ORIGINS: '["http://localhost:3000"]'
+      # Expose the MCP OAuth 2.1 authorization server so MCP clients can authenticate a user by
+      # logging in (in addition to API keys / personal access tokens). Uses FORGE_PUBLIC_BASE_URL
+      # for its discovery + redirect URLs. SECURITY: the consent/login screen is intentionally
+      # minimal and not yet hardened (minimal consent UX, no per-client consent memory, MFA
+      # accounts refused) - see forge/routers/mcp_oauth.py. Override to "false" for a real prod
+      # deploy until it's reviewed.
+      FORGE_MCP_OAUTH_ENABLED: ${FORGE_MCP_OAUTH_ENABLED:-true}
       # Static bearer that authenticates a trusted server-to-server caller (e.g. an app backend
       # driving runs on behalf of its users) as a least-privilege service identity. Empty =
       # disabled. Generate a long random secret and set FORGE_SERVICE_API_TOKEN in .env.

--- a/docs/reports/tool-sets-and-mcp-toolsets.md
+++ b/docs/reports/tool-sets-and-mcp-toolsets.md
@@ -1,0 +1,101 @@
+# Tool Sets & MCP Toolsets
+
+Status: Phases 1–3 are implemented and tested on branch `feat/tool-sets-and-mcp-toolsets` (not yet
+committed). The OAuth 2.1 authorization-server surface ships **default-OFF behind
+`FORGE_MCP_OAUTH_ENABLED`** and should get a security review before it is enabled in production
+(review notes at the end).
+
+## Concept
+
+A **tool set** is a describable group of tools. One concept serves two jobs:
+1. **Organization** — sets render as folders/filters on the Tools screen.
+2. **Exposure & assignment** — an agent can be granted a whole set, and the MCP server can publish
+   a set as a GitHub-style *toolset*.
+
+Membership is **many-to-many** (a tool can live in several sets). MCP itself has no native
+"toolset" primitive (still only a proposal upstream); toolsets are a server-side convention here.
+
+## What shipped
+
+### Phase 1 — Tool Sets
+- Entities `ToolSet` + `ToolSetMember` (`models/entities.py`); Alembic migration `0007_tool_sets.py`
+  (dev `create_all` builds them automatically).
+- `ToolSetService` (`services/tool_sets.py`) + router `/v1/projects/{id}/tool-sets`
+  (CRUD + `POST|DELETE /{set_id}/tools/{tool_id}` membership). Slugs are unique per project.
+- Agents: `agent config.toolsets: [set_id]` resolves to member tools at compile time
+  (`CompileContext.resolve_tool_ids`, union with `config.tools`, unknown ids tolerated).
+  `build_compile_context` loads `ctx.toolset_members` in one query.
+- Deleting a tool removes its membership rows (no DB cascade).
+- Web UI: Tools screen filter chips + "Tool sets" management modal; agent builder "Tool sets" chips
+  (workflow node inspector + Agents tab).
+
+### Phase 2 — Expose tool sets over MCP
+- Per-set endpoint: `POST /v1/mcp/{project_id}/toolset/{slug}` exposes only that set's tools.
+- Exposure is **toolset-driven** (GitHub-style): the surface is exactly the **enabled tools of
+  exposed tool sets** (`ToolSet.exposed`). There are no loose/"direct" tools — a tool that isn't in
+  an exposed set isn't published. (Superseded the earlier `mcp_published_toolsets` /
+  `mcp_exposed_tools` config.) MCP has no native "toolset" primitive, so the wire stays a flat
+  `tools/list`; tool sets are a Forge-side grouping we flatten (`_exposed_names` in mcp_server.py).
+- Connect screen: per-set **Expose** toggles, per-set URLs, a "currently exposed tools" summary,
+  and a step-by-step "How to use this MCP server" guide. Tools screen: a per-tool "Tool sets"
+  quick action to organize tools into sets.
+- **Connector role**: a least-privileged user (below viewer) — can authenticate, self-serve MCP
+  tokens, and use MCP, but the web console shows only a minimal "Your MCP access" page (no
+  projects/settings) and mutations are blocked by RBAC. Provision via Settings → Members.
+
+### Phase 3 (core) — Per-user identity over MCP
+- The MCP endpoint accepts, besides the shared `mcp_api_key`, a **project-scoped Forge session
+  token** (`create_session_token`) and resolves its `end_user`. `end_user` + the `X-Forge-Context`
+  header (`run_context`) are threaded into `build_compile_context` and the workflow-run path, so
+  entitlement gating and `{{ctx.*}}` injection act per user. The shared key remains for
+  server-to-server callers (no identity).
+
+## Auth model (agreed)
+
+Two hops, both authenticated:
+1. **Client → Forge**: standard bearer token so any MCP client works — shared project key
+   (server-to-server), a per-user session token (implemented), and later PAT / OAuth 2.1.
+2. **Forge → the customer's app (act as the user)**: a **separate** per-user credential resolved
+   server-side — never pass the MCP token through (MCP spec: token passthrough forbidden). The app
+   owner owns their own users/sessions; Forge only carries identity + (optionally) an out-of-band
+   session via `X-Forge-Context` → `{{ctx.session}}`.
+
+### Phase 3 (full) — the richer per-user auth layer (shipped)
+
+- **PAT** — per-user personal access token (`forge_pat_…`, on the `api_keys` table with `user_id`
+  + optional `project_id`). Endpoints `/v1/projects/{id}/mcp-tokens` (create/list/revoke, bound to
+  the logged-in user) + a Connect-screen card to generate/revoke. Resolved on the MCP endpoint to
+  an `end_user`; deliberately NOT a general-API principal (`get_current_user` only honors
+  `forge_sk_`). Paste into any MCP client.
+- **Per-user connected credentials** — an `AuthProvider` of kind `oauth2_authorization_code` with
+  `per_user_context_keys: ["end_user_id"]` keys its OAuth token bundle per end user. The tool
+  context now exposes `end_user_id` / `end_user_email`, so the resolver picks the acting user's
+  bundle. The app owner's connect flow stores each user's bundle via
+  `PUT /v1/projects/{id}/auth-providers/{apId}/connections/{endUserId}` (GET status / DELETE too).
+  No token passthrough — Forge holds a separate downstream credential per user.
+- **OAuth 2.1** (`forge.routers.mcp_oauth`, `FORGE_MCP_OAUTH_ENABLED`, default off) — Forge as an
+  OAuth 2.1 resource + authorization server: `/.well-known/oauth-protected-resource/v1/mcp/{id}`
+  and `/.well-known/oauth-authorization-server`, `WWW-Authenticate` challenge on a 401 from the MCP
+  endpoint, Dynamic Client Registration (RFC 7591), authorization-code + PKCE S256 with a
+  server-rendered login+consent, single-use authorization codes (jti revoke), and audience-bound
+  access tokens (RFC 8707; the resource is carried in a custom `res` claim rather than the JWT
+  `aud`, because the shared `decode_token` rejects tokens that carry `aud`). The MCP endpoint
+  accepts a valid access token as another `end_user` source.
+
+**OAuth security-review items (before enabling in prod):** the consent screen is a minimal
+server-rendered login form (no per-client consent memory, no branding); MFA-enabled accounts are
+**refused** here (no MFA bypass) and must use a PAT; add rate-limiting/lockout tuning on the
+consent POST; consider persisting/rotating client secrets if you later support confidential
+clients; review redirect-URI policy (currently exact-match, https-or-loopback).
+
+## Tests
+
+- `apps/api/tests/test_tool_sets.py`: tool-set service CRUD + membership + slug uniqueness,
+  tool-deletion cleanup, agent-toolset → member-tool resolution via `build_compile_context`, the
+  REST API (auth'd), MCP per-set / published-toolset scoping, session-token identity, and PAT
+  identity + the `/mcp-tokens` API.
+- `apps/api/tests/test_connected_credentials.py`: the AuthResolver picks each end user's own OAuth
+  bundle by `end_user_id`; connection status/clear.
+- `apps/api/tests/test_mcp_oauth.py`: discovery (404 when disabled), DCR, authorization-code +
+  PKCE end to end, token → MCP acceptance, audience binding, the 401 `WWW-Authenticate` challenge,
+  single-use codes, and PKCE enforcement.

--- a/packages/schemas/forge/nodes/agent.json
+++ b/packages/schemas/forge/nodes/agent.json
@@ -46,6 +46,7 @@
       }
     },
     "tools": { "type": "array", "items": { "type": "string" }, "description": "Tool ids (incl. MCP tool ids) available to the agent.", "x-ui": { "widget": "chips", "refType": "tool", "section": "Tools", "order": 4 } },
+    "toolsets": { "type": "array", "items": { "type": "string" }, "description": "Tool set ids granted to the agent - every tool in each set becomes available (in addition to any individually-listed tools).", "x-ui": { "widget": "chips", "refType": "tool_set", "section": "Tools", "order": 4.5 } },
     "knowledge": {
       "type": "object",
       "description": "Built-in knowledge-base access for the agent (no separate Tool needed). Compiles to agent-callable tools: RAG over documents and/or curated Q&A lookup, each scoped by folders/kinds. Prefer this over a fixed retrieval node for conversational or multi-part agents.",
@@ -126,6 +127,7 @@
             "description": { "type": "string", "x-ui": { "modelView": true } },
             "system_prompt": { "type": "string", "x-ui": { "widget": "textarea" } },
             "tools": { "type": "array", "items": { "type": "string" }, "x-ui": { "widget": "chips", "refType": "tool" } },
+            "toolsets": { "type": "array", "items": { "type": "string" }, "x-ui": { "widget": "chips", "refType": "tool_set" } },
             "model": { "$ref": "forge/common#/$defs/ModelRef" },
             "middleware": { "type": "array", "items": { "$ref": "forge/middleware#/$defs/MiddlewareEntry" } }
           }


### PR DESCRIPTION
First-class many:many tool sets that double as UI folders and the unit exposed over MCP, plus a per-project MCP server with three authentication modes.

Backend:
- Tool sets service, router, and migrations (membership + exposed flag).
- MCP server endpoint (base + per-toolset scoped) with auth precedence: shared API key -> per-user personal access token -> OAuth 2.1.
- OAuth 2.1 authorization server (auth-code + PKCE, dynamic client registration, RFC 8707 resource binding), gated by FORGE_MCP_OAUTH_ENABLED, with a Forge-branded consent screen.

Web:
- Tools screen redesign: toolset sidebar (All / Ungrouped / sets), multi-select bulk assign, per-card menu, and a Manage toolsets drawer.
- Connect -> MCP: single + scoped endpoints; API key / PAT as either-or tabs; how-to guide collapsed by default.
- Settings -> General: surfaces the workspace (tenant) id for OAuth login.

Ops:
- docker-compose: FORGE_MCP_OAUTH_ENABLED (defaults true; override to false for prod until the consent flow is hardened).

<!-- Thanks for contributing to Forge! Please fill this out to speed up review. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link the issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance
- [x] Refactor (no behavior change)
- [ ] Docs / chore

## Checklist

- [x] Backend: `ruff check forge migrations` is clean and `pytest -q` passes (from `apps/api`)
- [ ] New/changed backend code is `mypy`-clean
- [x] Frontend: `pnpm --filter web build` passes (from repo root)
- [ ] Shared schemas (`packages/schemas`) updated if node/tool config changed
- [ ] Tests added/updated for the change (characterization test for behavior-preserving refactors)
- [ ] `CHANGELOG.md` updated under **Unreleased** (for user-facing changes)
- [ ] No secrets, tokens, or customer data in the diff

## Notes for reviewers

<!-- Anything that needs special attention, screenshots for UI changes, migration notes, etc. -->
